### PR TITLE
Adds a UI option to only practice on X number of questions. 

### DIFF
--- a/layouts/partials/quizdown.html
+++ b/layouts/partials/quizdown.html
@@ -8,15 +8,27 @@ src="https://cdn.jsdelivr.net/npm/quizdown@latest/public/build/extensions/quizdo
 src="https://cdn.jsdelivr.net/npm/quizdown@latest/public/build/extensions/quizdownHighlight.js">
 </script>
 <script>
+// If the question options is available as a querystring param, let's use that.
+    let urlParams = new URLSearchParams(window.location.search);
+    let nQuestionsParam = urlParams.get('questions');
+
     let config = {
-        startOnLoad: true,          // detect and convert all div html elements with class quizdown
-        shuffleAnswers: {{ with .Page.Params.shuffleAnswers }} {{ . }} {{ else }} true {{ end }},      // shuffle answers for each question
-        shuffleQuestions: {{ with .Page.Params.shuffleQuestions }} {{ . }} {{ else }} false {{ end }},    // shuffle questions for each quiz
-        nQuestions: {{ with .Page.Params.nQuestions }} {{ . }} {{ else }} undefined {{ end }},      // display n questions at random, if shuffleQuestions is true
-        primaryColor: 'steelblue',  // primary CSS color
-        secondaryColor: '#f2f2f2',  // secondary CSS color
-        textColor: 'black',         // text color of some elements
-        locale: null                // language of the user interface (auto-detect per default)
+        // detect and convert all div html elements with class quizdown
+        startOnLoad: true,          
+        // shuffle answers for each question
+        shuffleAnswers: {{ with .Page.Params.shuffleAnswers }} {{ . }} {{ else }} true {{ end }},      
+        // shuffle questions for each quiz
+        shuffleQuestions:nQuestionsParam ? true : {{ with .Page.Params.shuffleQuestions }} {{ . }} {{ else }} false {{ end }},    
+        // display n questions at random, if shuffleQuestions is true
+        nQuestions: nQuestionsParam ? parseInt(nQuestionsParam) : {{ with .Page.Params.nQuestions }} {{ . }} {{ else }} undefined {{ end }},      
+        // primary CSS color
+        primaryColor: 'steelblue',  
+        // secondary CSS color
+        secondaryColor: '#f2f2f2',  
+        // text color of some elements
+        textColor: 'black',         
+        // language of the user interface (auto-detect per default)
+        locale: null                
     };
     quizdown.register(quizdownHighlight).register(quizdownKatex).init(config)
 </script>

--- a/layouts/shortcodes/test_cards.html
+++ b/layouts/shortcodes/test_cards.html
@@ -20,7 +20,7 @@
                 {{ end }}
             </ul>
             {{ if gt $question_count 30 }}
-                <a href="{{ .Permalink }}" class="btn">Start</a>
+                <a href="{{ .Permalink }}" class="btn start-button">Start</a>
             {{ else }}
                 <a href="/" class="btn disabled">Unavailable</a>
             {{ end }}
@@ -28,3 +28,30 @@
     </div>
 
 {{ end }}
+</div>
+
+<h4>Advanced settings</h4>
+<section class="advanced-settings">
+    <script>
+        function setNumberOfQuestions(numberOfQuestions) {
+            var links = document.getElementsByClassName('start-button');
+
+            for (var i = 0; i < links.length; i++) {
+                var url = new URL(links[i].href);
+                var params = new URLSearchParams(url.search);
+                params.set('questions', numberOfQuestions ? parseInt(numberOfQuestions, 10) : '');
+                links[i].href = url.origin + url.pathname + '?' + params.toString();
+            }
+        }
+    </script>
+
+    <label for="numberOfQuestions">Limit number of questions. Leave blank for all questions.</label>
+    <input 
+        type="number" 
+        value="" 
+        step="1"
+        id="numberOfQuestions" 
+        placeholder="Number or blank for all" 
+        onchange="setNumberOfQuestions(this.value)"
+    />
+</section> 

--- a/static/css/practice-tests.css
+++ b/static/css/practice-tests.css
@@ -109,6 +109,13 @@
   color: #e8e8e8;
 }
 
+.advanced-settings {
+  padding: 24px;
+  margin: 2px;
+  border-radius: 10px;
+  background-color: #f5f5f5;
+}
+
 @media (max-width: 1300px) {
   .exam-container {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## PR Type
New feature

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.`
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
On the page for all exams this PR adds a section below the cards to allow the user to only practice on X number of questions. 

In the quizdown.html the querystring is checked for the questions parameter, and if present, will use that value to limit number of questions in the quiz.


## Related issue(s)
#144 

## Screenshots
<img alt="image" src="https://github.com/FidelusAleksander/ghcertified/assets/860380/852193d4-0db1-4fcc-8107-e5cc8edd4d9e">

