### PR TITLE
Add expandable sections in Contributed Questions page

### DIFF
--- a/content/questions/_index.md
+++ b/content/questions/_index.md
@@ -12,18 +12,34 @@ This page contains all the questions that were [contributed](https://github.com/
 
 {{% /notice %}}
 
-## GitHub Actions
+
+
+{{< expand title="**GitHub Foundations questions**" >}}
+
+{{< library-links questions="GitHub Foundations" >}}
+
+{{< /expand >}}
+
+
+
+{{< expand title="**GitHub Actions questions**" >}}
 
 {{< library-links questions="GitHub Actions" >}}
 
-## GitHub Admin
+{{< /expand >}}
+
+
+
+{{< expand title="**GitHub Admin questions**" >}}
 
 {{< library-links questions="GitHub Admin" >}}
 
-## GitHub Advanced Security
+{{< /expand >}}
+
+
+
+{{< expand title="**GitHub Advanced Security questions**" >}}
 
 {{< library-links questions="GitHub Advanced Security" >}}
 
-## GitHub Foundations
-
-{{< library-links questions="GitHub Foundations" >}}
+{{< /expand >}}


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.`
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Make the sections the Contributed Questions page expandable

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
![image](https://github.com/FidelusAleksander/ghcertified/assets/63016446/f9cd63e5-5192-4bda-93f1-95abbabdbdbe)
