### PR TITLE
Change Permalinks to RelPermalinks

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,12 +7,12 @@ archetype: "home"
 
 This website is a collaborative project dedicated to assisting individuals in their preparation for the [GitHub Certification](https://resources.github.com/learn/certifications/) exams.
 
-It is recommended to first take a look at the list of [study resources]({{% ref "study_resources" %}}) and follow up with attempting our community made [practice tests]({{% ref "practice_tests" %}}).
+It is recommended to first take a look at the list of [study resources]({{% relref "study_resources" %}}) and follow up with attempting our community made [practice tests]({{% relref "practice_tests" %}}).
 
 
 ## Practice test taking
 
 
-[**Click here**]({{% ref "practice_tests" %}}) to attempt our free and open-source practice tests, which are designed to simulate the real exam experience, allowing you to assess your skills and boost your confidence.
+[**Click here**]({{% relref "practice_tests" %}}) to attempt our free and open-source practice tests, which are designed to simulate the real exam experience, allowing you to assess your skills and boost your confidence.
 
 {{< figure src="/images/practice_tests.gif" alt="Practice Tests" >}}

--- a/layouts/shortcodes/library-links.html
+++ b/layouts/shortcodes/library-links.html
@@ -1,7 +1,7 @@
 <ol>
 {{ range where (where .Site.RegularPages ".Params.exam" .Params.questions) "Section" "questions" }}
 <li>
-    <a href="{{ .Permalink }}">{{ .Params.question }}</a>
+    <a href="{{ .RelPermalink }}">{{ .Params.question }}</a>
 </li>    
 {{ end }}
 </ol>

--- a/layouts/shortcodes/test_cards.html
+++ b/layouts/shortcodes/test_cards.html
@@ -3,7 +3,7 @@
 {{ range where .Site.RegularPages "Section" "practice_tests" }}
     {{ $include_exam := .Page.Params.include_exam }}
     <div class="card">
-        <form class="content" action="{{ .Permalink }}" method="get">
+        <form class="content" action="{{ .RelPermalink }}" method="get">
             <img src="/images/{{.Params.badge}}" alt="advanced_security_badge" style="max-width: 100%;">
             {{ $questionCount := len (where (where .Site.RegularPages "Section" "questions") "Params.exam" $include_exam) }}
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.`
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
When working on Codespaces the permalinks were redirecting to localhost instead of the codespace domain

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
