### PR TITLE
Fixing question 31 for the GHAS Exam

### DIFF
--- a/content/questions/advanced_security/question-031.md
+++ b/content/questions/advanced_security/question-031.md
@@ -9,7 +9,7 @@ draft: false
 > https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts
 - [x] They partially rely on the GitHub Advisory Database
 - [x] To enable Dependabot Alerts you first need to have Dependency Graph enabled on your repository
-- [x] When GitHub identifies a vulnerable dependency or malware, they generate a Dependabot alert and display it on the Security tab for the repository 
+- [x] When GitHub identifies a vulnerable dependency, they generate a Dependabot alert and display it on the Security tab for the repository 
 - [ ] Dependabot Alerts are enabled by default for all repositories
 - [ ] Dependabot Alerts are enabled by default for all public repositories
 - [ ] Dependabot alerts tell you that your repository uses an outdated version of a package


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [X] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
According to the documentation: "Dependabot doesn't generate Dependabot alerts for malware". So, the answer 

_When GitHub identifies a vulnerable dependency **or malware**, they generate a Dependabot alert and display it on the Security tab for the repository_

is being changed by 

_When GitHub identifies a vulnerable dependency, they generate a Dependabot alert and display it on the Security tab for the repository_

Source: https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts



## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
