### PR TITLE
Add menu item for GitHub Discussions

### DIFF
--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -15,3 +15,9 @@ name = "<i class='fas fa-fw fa-calendar'></i> Official Site"
 identifier = "Certifications"
 url = "https://resources.github.com/learn/certifications/"
 weight = 30
+
+[[shortcuts]]
+name = "<i class='fas fa-fw fa-comments'></i> Discussions"
+identifier = "Discussions"
+url = "https://github.com/FidelusAleksander/ghcertified/discussions"
+weight = 40


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Side menu now has extra link/icon leading to [GitHub Discussions](https://github.com/FidelusAleksander/ghcertified/discussions)

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
![image](https://github.com/FidelusAleksander/ghcertified/assets/63016446/e6d5848f-031c-4de2-a616-20fb651a736e)
