### PR TITLE
fix #252 - update outdated answer

### DIFF
--- a/content/questions/actions/question-116.md
+++ b/content/questions/actions/question-116.md
@@ -1,12 +1,12 @@
 ---
-question: "When can you delete workflow runs (Select two.)"
+question: "When can you delete workflow runs?"
 archetype: "questions"
 title: "Question 116"
 draft: false
 ---
 
 > https://docs.github.com/en/actions/managing-workflow-runs/deleting-a-workflow-run
-- [x] When workflow run has been completed
-- [x] When workflow run is two weeks old
-- [ ] When workflow run is 10 days old
-- [ ] When workflow run is in progress
+1. [x] When workflow run has been completed
+1. [ ] When workflow run is two weeks old
+1. [ ] When workflow run is 10 days old
+1. [ ] When workflow run is in progress


### PR DESCRIPTION
## PR Type
Fixing the question 116 answer.

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [X] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
- Change the answer type from multi select option to unique choice. 
- Remove "When workflow run is two weeks old" from good answers.
- Adapt question sentence.

## Related issue(s)
[Issue 252](https://github.com/FidelusAleksander/ghcertified/issues/252).

## Screenshots
No screenshots.
