### PR TITLE
Preview deployments on labeled pull requests

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -1,16 +1,18 @@
-name: Deploy Preview
+name: Deploy Preview Site
 
 on:
-  workflow_dispatch:
-#  pull_request:
-#    types:
-#      - labeled
+  pull_request:
+    types:
+      - labeled
 
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages
-#    if: github.event.label.name == 'request-preview-deployment'
+    if: github.event.label.name == 'request-preview-deployment'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +26,70 @@ jobs:
       - name: Build site
         run: hugo
       - name: Deploy to Cloudflare Pages
+        id: deploy
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
           directory: 'public/'
+          branch: ${{ github.event.pull_request.head.ref }}
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Preview Environment
+
+      - name: Create comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **✅ Preview Environment Ready!**
+            
+            | Name | Link |
+            | --- | --- |
+            | :link: Preview Url | ${{ steps.deploy.outputs.alias }} |
+            
+            Please verify everything looks as expected.
+
+
+          reactions: rocket
+
+      - name: Update comment
+        if: steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            **✅ Preview Environment was deployed again!**
+
+            | Name | Link |
+            | --- | --- |
+            | :link: Preview Url | ${{ steps.deploy.outputs.alias }} |
+            | :hammer: Latest Commit | ${{ github.event.pull_request.head.sha }} |
+            | :clock10: Latest Deploy | ${{ github.event.pull_request.updated_at }} |
+            
+            Please verify everything looks as expected.
+          reactions: hooray
+          edit-mode: 'replace'
+
+      - name: Remove Label
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = context.issue.number;
+            const labelToRemove = 'request-preview-deployment';
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              name: labelToRemove
+            });


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [x] Other


## What's new?
<!-- Describe what this PR changes -->
Pull requests can now be labeled with `request-review-deployment` to trigger a preview cloudflare build

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
