### PR TITLE
Fix incorrect information about matrix strategy for entire workflows

### DIFF
--- a/content/questions/actions/question-014.md
+++ b/content/questions/actions/question-014.md
@@ -15,5 +15,5 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 ```
 > https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow
-1. [ ] No
-1. [x] Yes
+1. [x] No
+1. [ ] Yes


### PR DESCRIPTION
This pull request addresses an error in the documentation that incorrectly suggested that the matrix strategy can parallelize entire workflows. 

The matrix strategy is used to run multiple jobs within a **single workflow** based on a combination of variables, but it does not apply to parallelizing across workflows. This correction ensures that users have the right information when configuring their GitHub Actions workflows.


## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
Updated documentation to reflect that the matrix strategy only applies to jobs within a workflow, not across multiple workflows.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
