### PR TITLE
correcting the 116th question answer (suppose to be two correct options)

### DIFF
--- a/content/questions/actions/question-014.md
+++ b/content/questions/actions/question-014.md
@@ -15,5 +15,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 ```
 > https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow
-1. [x] No
-1. [ ] Yes
+
+1. [ ] No
+1. [x] Yes

--- a/content/questions/actions/question-116.md
+++ b/content/questions/actions/question-116.md
@@ -1,5 +1,5 @@
 ---
-question: "When can you delete workflow runs? (selct two)"
+question: "When can you delete workflow runs? (select two)"
 archetype: "questions"
 title: "Question 116"
 draft: false

--- a/content/questions/actions/question-116.md
+++ b/content/questions/actions/question-116.md
@@ -1,5 +1,5 @@
 ---
-question: "When can you delete workflow runs?"
+question: "When can you delete workflow runs? (selct two)"
 archetype: "questions"
 title: "Question 116"
 draft: false
@@ -7,6 +7,6 @@ draft: false
 
 > https://docs.github.com/en/actions/managing-workflow-runs/deleting-a-workflow-run
 1. [x] When workflow run has been completed
-1. [ ] When workflow run is two weeks old
+1. [x] When workflow run is two weeks old
 1. [ ] When workflow run is 10 days old
 1. [ ] When workflow run is in progress


### PR DESCRIPTION
PR Type
 content changes (updating questions, answers, explanations or study resources)

What's new?
This PR corrects the answer for the 116th question, as it previously listed only one correct answer. 
The question now has two correct options.

Screenshots
![Doc](https://github.com/user-attachments/assets/dbfbc55f-53e9-41d3-98ac-d3ee710bce11)





