### PR TITLE
Fix duplicate options in GitHub Actions status check functions question

### DIFF
--- a/content/questions/actions/question-100.md
+++ b/content/questions/actions/question-100.md
@@ -6,6 +6,6 @@ title: "Question 100"
 
 > https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
 1. [x] `success()`, `always()`, `cancelled()` and `failure()`
-1. [ ] `status()`, `always()`, `cancelled()` and `failure()`
+1. [ ] `completed()`, `always()`, `cancelled()` and `failure()`
 1. [ ] `status()`, `always()`, `cancelled()` and `failure()`
 1. [ ] `state()`, `always()`, `cancelled()` and `failure()`


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other

## What's new?
Fixed duplicate answer options in q 100 about GitHub Actions status check functions.
Updated option 3 from `status()` to `completed()` to make all options distinct while maintaining the correct answer.

## Related issue(s)
N/A

## Screenshots
N/A
