### PR TITLE
add question 124 for github actions

### DIFF
--- a/content/questions/actions/question-124.md
+++ b/content/questions/actions/question-124.md
@@ -18,8 +18,8 @@ strategy:
 
 > https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations
 
-- [ ] 4 jobs
-- [x] 5 jobs
-- [ ] 6 jobs
-- [ ] 7 jobs
-- [ ] No jobs will run because the syntax is invalid.
+1. [ ] 4 jobs
+1. [x] 5 jobs
+1. [ ] 6 jobs
+1. [ ] 7 jobs
+1. [ ] No jobs will run because the syntax is invalid.

--- a/content/questions/actions/question-124.md
+++ b/content/questions/actions/question-124.md
@@ -1,0 +1,25 @@
+---
+question: "Given the following configuration, how many jobs will GitHub Actions run when this matrix is evaluated?"
+archetype: "questions"
+title: "Question 124"
+---
+
+```yaml
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest]
+    node: [14, 16]
+    include:
+      - os: macos-latest
+        node: 18
+      - os: ubuntu-latest
+        node: 14
+```
+
+> https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations
+
+- [ ] 4 jobs
+- [x] 5 jobs
+- [ ] 6 jobs
+- [ ] 7 jobs
+- [ ] No jobs will run because the syntax is invalid.


### PR DESCRIPTION
## PR Type
- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
Adds a new question about using matrix in GitHub Actions. The repo already has some questions on matrix, but this one focuses on the include key, specifically a case where one of the include entries overlaps with what's already defined in the main matrix.

I came up with this question after recently passing the certification — I didn’t copy it from the test, just recreated it knowing that the key part was to make "include" match an occurrence of the matrix. After the exam, I asked ChatGPT about it, but the answer it gave was wrong, so I ran the scenario myself to double-check the correct behavior.

## Related issue(s)


## Screenshots

