### PR TITLE
add question 126 about referencing outputs using `needs.job.outputs.o…

### DIFF
--- a/content/en/questions/actions/question-126.md
+++ b/content/en/questions/actions/question-126.md
@@ -5,7 +5,7 @@ question: "How should a dependent job reference the `output1` value produced by 
 
 > https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
 
-- [x] `${{needs.job1.outputs.output1}}`
-- [ ] `${{job1.outputs.output1}}`
-- [ ] `${{needs.job1.output1}}`
-- [ ] `${{depends.job1.output1}}`
+1. [x] `${{needs.job1.outputs.output1}}`
+1. [ ] `${{job1.outputs.output1}}`
+1. [ ] `${{needs.job1.output1}}`
+1. [ ] `${{depends.job1.output1}}`


### PR DESCRIPTION

## PR Type

- [x] Adding new question(s)  
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.

## What's new?

Added `question-126.md` under the `questions/actions` directory.  
This question checks knowledge of how to correctly access the output (`output1`) of an upstream job (`job1`) from a dependent job using the `needs.job1.outputs.output1` syntax.

Includes valid distractors and a source link to the official GitHub documentation for passing outputs between jobs:  
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs

## Related issue(s)

N/A – independent contribution for expanding the question set.

## Screenshots

N/A – markdown-only update.
