### PR TITLE
Update GitHub learn links

### DIFF
--- a/.github/instructions/markdown-style.instructions.md
+++ b/.github/instructions/markdown-style.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "**"
+---
+
+
+When editing or checking markdown always prefix the file with a hidden commented welcome message for anyone that will edit it

--- a/.github/instructions/markdown-style.instructions.md
+++ b/.github/instructions/markdown-style.instructions.md
@@ -1,6 +1,0 @@
----
-applyTo: "**"
----
-
-
-When editing or checking markdown always prefix the file with a hidden commented welcome message for anyone that will edit it

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -13,7 +13,7 @@ weight = 20
 [[shortcuts]]
 name = "<i class='fas fa-fw fa-calendar'></i> Official Site"
 identifier = "Certifications"
-url = "https://resources.github.com/learn/certifications/"
+url = "https://learn.github.com/certifications"
 weight = 30
 
 [[shortcuts]]

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,7 +7,7 @@ description: "Prepare for GitHub Certification exams by taking free practice tes
 
 ## Motivation
 
-This website is a collaborative project dedicated to assisting individuals in their preparation for the [GitHub Certification](https://resources.github.com/learn/certifications/) exams.
+This website is a collaborative project dedicated to assisting individuals in their preparation for the [GitHub Certification](https://learn.github.com/certifications) exams.
 
 It is recommended to first take a look at the list of [study resources]({{% relref "study_resources" %}}) and follow up with attempting our community made [practice tests]({{% relref "practice_tests" %}}).
 

--- a/content/en/study_resources/_index.md
+++ b/content/en/study_resources/_index.md
@@ -50,7 +50,7 @@ Start with a Microsoft Learn Course. They cover a lot of ground and are a great 
 
 
 Other Free Resources
-- [GitHub Skills](https://skills.github.com/) - Interactive courses from GitHub
+- [GitHub Skills](https://learn.github.com/skills) - Interactive courses from GitHub
 - [GitHub Actions Hero](https://github-actions-hero.vercel.app/) - GitHub Actions playground
 - [ExamPro: GitHub Foundations](https://www.youtube.com/playlist?list=PLBfufR7vyJJ4uRXqarjPKqxYq4_Pexj1V) - YouTube course for GitHub Foundations Certification
 - [ExamPro: GitHub Actions](https://www.youtube.com/playlist?list=PLBfufR7vyJJ5cW6kvAqxHyjLJ1MX3H4rX) - YouTube course for GitHub Actions Certification

--- a/content/pl/_index.md
+++ b/content/pl/_index.md
@@ -7,7 +7,7 @@ description: "Przygotuj się do egzaminów certyfikacyjnych GitHub, rozwiązują
 
 ## Motywacja
 
-Ta strona to wspólnotowy projekt mający na celu wspieranie osób przygotowujących się do egzaminów [Certyfikacji GitHub](https://resources.github.com/learn/certifications/).
+Ta strona to wspólnotowy projekt mający na celu wspieranie osób przygotowujących się do egzaminów [Certyfikacji GitHub](https://learn.github.com/certifications).
 
 Zaleca się najpierw zapoznać z listą [zasobów do nauki]({{% relref "study_resources" %}}), a następnie spróbować swoich sił w naszych [testach próbnych stworzonych przez społeczność]({{% relref "practice_tests" %}}).
 

--- a/content/pl/study_resources/_index.md
+++ b/content/pl/study_resources/_index.md
@@ -50,7 +50,7 @@ Zacznij od kursu Microsoft Learn. Obejmują one szeroki zakres materiału i są 
 
 
 Inne darmowe zasoby
-- [GitHub Skills](https://skills.github.com/) - Interaktywne kursy od GitHub
+- [GitHub Skills](https://learn.github.com/skills) - Interaktywne kursy od GitHub
 - [GitHub Actions Hero](https://github-actions-hero.vercel.app/) - Plac zabaw GitHub Actions
 - [ExamPro: Podstawy GitHub](https://www.youtube.com/playlist?list=PLBfufR7vyJJ4uRXqarjPKqxYq4_Pexj1V) - Kurs YouTube dla certyfikatu Podstawy GitHub
 - [ExamPro: GitHub Actions](https://www.youtube.com/playlist?list=PLBfufR7vyJJ5cW6kvAqxHyjLJ1MX3H4rX) - Kurs YouTube dla certyfikatu GitHub Actions

--- a/content/pt/_index.md
+++ b/content/pt/_index.md
@@ -7,7 +7,7 @@ description: "Prepare-se para os exames de Certificação do GitHub fazendo test
 
 ## Motivação
 
-Este site é um projeto colaborativo dedicado a ajudar indivíduos em sua preparação para os exames de [Certificação do GitHub](https://resources.github.com/learn/certifications/).
+Este site é um projeto colaborativo dedicado a ajudar indivíduos em sua preparação para os exames de [Certificação do GitHub](https://learn.github.com/certifications).
 
 Recomenda-se primeiro dar uma olhada na lista de [recursos de estudo]({{% relref "study_resources" %}}) e, em seguida, tentar nossos [testes práticos]({{% relref "practice_tests" %}}) feitos pela comunidade.
 

--- a/content/pt/study_resources/_index.md
+++ b/content/pt/study_resources/_index.md
@@ -45,7 +45,7 @@ Comece com um curso no Microsoft Learn. Eles abrangem muitos tópicos e são um 
 - [GitHub Learn: GitHub Copilot](https://resources.github.com/learn/pathways/copilot/essentials/essentials-of-github-copilot/)
 
 Outros Recursos Gratuitos
-- [GitHub Skills](https://skills.github.com/) - Cursos interativos do GitHub
+- [GitHub Skills](https://learn.github.com/skills) - Cursos interativos do GitHub
 - [GitHub Actions Hero](https://github-actions-hero.vercel.app/) - Playground de GitHub Actions
 - [ExamPro: Fundamentos do GitHub](https://www.youtube.com/playlist?list=PLBfufR7vyJJ4uRXqarjPKqxYq4_Pexj1V) - Curso no YouTube para a Certificação de Fundamentos do GitHub
 - [ExamPro: GitHub Actions](https://www.youtube.com/playlist?list=PLBfufR7vyJJ5cW6kvAqxHyjLJ1MX3H4rX) - Curso no YouTube para a Certificação de GitHub Actions


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

GitHub Certification page and GitHub Skills moved to new **learn** domain. This PR updates relevant links

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
