### PR TITLE
feat: switch on multilanguage content

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -18,7 +18,7 @@ editURL = "https://github.com/FidelusAleksander/ghcertified/edit/master/content/
 author.name = "Aleksander Fidelus"
 
 # Disable the language switching button until the site is fully translated
-disableLanguageSwitchingButton = true
+disableLanguageSwitchingButton = false
 
 
 # Images for OpenGraph

--- a/content/pl/questions/actions/question-010.md
+++ b/content/pl/questions/actions/question-010.md
@@ -7,4 +7,3 @@ title: "Pytanie 010"
 1. [ ] config variables
 1. [ ] vault
 1. [ ] environment variables
----


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

This PR switches on the feature to show the site in multiple languages.



A new dropdown menu on the sidebar allowing you to choose the language

<img width="295" height="209" alt="image" src="https://github.com/user-attachments/assets/0902782c-f7c6-4664-94bc-c491454468a7" />

<img width="285" height="122" alt="image" src="https://github.com/user-attachments/assets/d2457ad5-a944-4eab-8df9-53aa1f5b17c2" />

All of the translations are generated by GitHub Models using custom [translation prompt](https://github.com/FidelusAleksander/ghcertified/blob/master/.github/translation-system-prompt.md). 

The prompt will likely be improved and other languages added in the future!

## Related issue(s)
<!-- If applicable link to related issues -->
Closes: https://github.com/FidelusAleksander/ghcertified/issues/344

## Screenshots
<!-- (optional) Include related screenshots -->
