### PR TITLE
Correct Question 44

### DIFF
--- a/content/en/questions/actions/question-044.md
+++ b/content/en/questions/actions/question-044.md
@@ -5,7 +5,7 @@ title: "Question 044"
 
 
 > https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#about-workflow-artifacts
-1. [x] You cannot access `artifacts` that were created in a different workflow run
-1. [ ] Use the `actions/download-artifact` action.
+1. [ ] You cannot access `artifacts` that were created in a different workflow run
+1. [x] Use the `actions/download-artifact` action with elevated permissions.
 1. [ ] Use the `actions/upload-artifact` action.
 1. [ ] Use the `actions/download-artifact` action and make sure the artifact is not expired


### PR DESCRIPTION
By default, the permissions are scoped so they can only download Artifacts within the current workflow run. To elevate permissions for this scenario, you can specify a github-token along with other repository and run identifiers

GitHub Documentation: https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories

## PR Type
Update GitHub Action Question 44 to be compliant with the GitHub documentation

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
The PR changes the answer from "You cannot access artifacts that were created in a different workflow run" to "Use the actions/download-artifact action" with the addition "with elavated permissions"

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
