### PR TITLE
fix: update link to default environment variables documentation

### DIFF
--- a/content/en/questions/actions/question-061.md
+++ b/content/en/questions/actions/question-061.md
@@ -4,7 +4,7 @@ title: "Question 061"
 ---
 
 
-> https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+> https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
 
 - [x] `GITHUB_REPOSITORY`
 - [x] `GITHUB_WORKFLOW`


### PR DESCRIPTION
## PR Type
Answer documentation update.

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
This pull request updates a documentation link in the `content/en/questions/actions/question-061.md` file to point to the correct reference for default environment variables in GitHub Actions.

* Updated the documentation link to reference the correct page for default environment variables in workflows and actions.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
