### PR TITLE
Update practice_test.html

### DIFF
--- a/layouts/shortcodes/practice_test.html
+++ b/layouts/shortcodes/practice_test.html
@@ -1,4 +1,4 @@
-<base target="_blank">
+<base>
 
 
 {{ partial "quizdown.html" }}


### PR DESCRIPTION
fix bug that opens a new tab everytime you click the practice exam link

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
Removed target attribute from practice_exam shortcode to avoid opening a new tab everytime the link is clicked.