### PR TITLE
fix: disable question map large view on mobile and fix title on practice tests page

### DIFF
--- a/app/src/app/[locale]/practice-tests/page.tsx
+++ b/app/src/app/[locale]/practice-tests/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
 }: Props): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "PracticeTests" });
-  const title = t("title");
+  const title = `${t("title1")} ${t("title2")}`;
   const description = t("description");
 
   return {

--- a/app/src/components/quiz/Quiz.tsx
+++ b/app/src/components/quiz/Quiz.tsx
@@ -384,7 +384,7 @@ export function Quiz({ questions, questionCount, cert, certName }: QuizProps) {
           )}
 
           {/* Question Map */}
-          <Card className="shadow-sm border-[1.5px]">
+          <Card className="hidden lg:block shadow-sm border-[1.5px]">
             <CardHeader className="p-5 pb-0">
               <CardTitle className="font-display text-[11px] font-bold tracking-[1px] uppercase text-muted-foreground">
                 {mapTotalPages > 1 ? t("mapRange", { start: mapStart + 1, end: mapEnd, total: quizQuestions.length }) : t("questionMap")}
@@ -586,4 +586,3 @@ export function Quiz({ questions, questionCount, cert, certName }: QuizProps) {
     </div>
   );
 }
-


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

This pull request introduces a minor update to the practice tests page metadata and improves the user interface of the quiz component. The most notable changes are a refinement of the page title for better clarity and a UI adjustment to the question map for responsive design.

Metadata improvements:
* Updated the practice tests page title to combine two translation strings, providing a more descriptive and dynamic title. ([app/src/app/[locale]/practice-tests/page.tsxL24-R24](diffhunk://#diff-365f28727e9b45d387306766e96e0c4ba50ef1babb53fcdf01c01f1f3abfd759L24-R24))

Quiz component UI enhancements:
* Made the question map (`Card` component) visible only on large screens (`lg` and up), hiding it on smaller devices to improve mobile usability.

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
