### PR TITLE
fix: wrap LeaderboardPage in Suspense for useSearchParams

### DIFF
--- a/app/src/app/[locale]/challenges/leaderboard/page.tsx
+++ b/app/src/app/[locale]/challenges/leaderboard/page.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
 import { LeaderboardPage } from "./leaderboard-page";
@@ -44,7 +45,9 @@ export default async function FullLeaderboardRoute({ params }: Props) {
         </p>
       </div>
 
-      <LeaderboardPage locale={locale} />
+      <Suspense>
+        <LeaderboardPage locale={locale} />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
Fixes build failure introduced by switching leaderboard tab deep-linking from hash fragments (`#time-trial`) to query params (`?tab=time-trial`) in #544.

`useSearchParams()` requires a `<Suspense>` boundary during static export (`output: 'export'`). Without it, the build fails:

```
useSearchParams() should be wrapped in a suspense boundary at page "/[locale]/challenges/leaderboard"
```

Wraps `<LeaderboardPage>` in `<Suspense>` in the server page component.