### PR TITLE
ci: add build check to PR workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,3 +42,16 @@ jobs:
         working-directory: app
       - run: npm test
         working-directory: app
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.node-version'
+      - run: npm ci
+        working-directory: app
+      - run: npm run build
+        working-directory: app


### PR DESCRIPTION
Adds an `npm run build` job to the PR Checks workflow. This catches build failures (e.g. missing Suspense boundaries for `useSearchParams`) before merge.

Motivated by the build failure in #544 that wasn't caught by existing CI checks (pre-commit, spell-check, unit-tests).