### PR TITLE
fix: update suggest challenge text to reference Discussions

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -157,7 +157,7 @@
     "suggestChallengeButton": "Suggest a Challenge →",
     "voteOnIdeas": "Vote on Ideas →",
     "community": "Community",
-    "suggestRule1": "Propose a new game mode via the issue form",
+    "suggestRule1": "Propose a new game mode via GitHub Discussions",
     "suggestRule2": "Vote on existing ideas with reactions",
     "suggestRule3": "Top-voted suggestions get built next",
     "play": "Play →",


### PR DESCRIPTION
The suggest-a-challenge card rule still said "via the issue form". Challenge ideas are now proposed via GitHub Discussions.

Changed `suggestRule1` in `en.json`:
- **Before:** "Propose a new game mode via the issue form"
- **After:** "Propose a new game mode via GitHub Discussions"

Other locale files are maintained by the external translation process and will pick up the change automatically.