### PR TITLE
feat: add progress and counters to game sidebars

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -171,6 +171,7 @@
     "leaderboardEmpty": "No scores yet — be first on the board.",
     "leaderboardUnavailable": "Leaderboard unavailable right now.",
     "score": "Score",
+    "progress": "Progress",
     "viewProfile": "View GitHub profile",
     "gauntletRule1": "You get {lives} lives — mess up and they're gone forever 💀",
     "gauntletRule2": "{seconds}s on the clock per question — tick tock!",

--- a/app/src/components/challenges/ChallengeSidebar.tsx
+++ b/app/src/components/challenges/ChallengeSidebar.tsx
@@ -105,6 +105,10 @@ interface ChallengeSidebarProps {
   /** Label for the score row (e.g. "Score"). */
   scoreLabel: string;
   scoreValue: number;
+  /** Question progress slot (e.g. "12 / 50"). */
+  progressSlot?: ReactNode;
+  /** Correct/incorrect counters slot. */
+  countersSlot?: ReactNode;
   /** Pause control — pass undefined when pausing isn't available. */
   pauseSlot?: ReactNode;
 }
@@ -117,6 +121,8 @@ export function ChallengeSidebar({
   timerExtra,
   scoreLabel,
   scoreValue,
+  progressSlot,
+  countersSlot,
   pauseSlot,
 }: ChallengeSidebarProps) {
   return (
@@ -156,6 +162,16 @@ export function ChallengeSidebar({
               <span className="font-display text-[18px] font-extrabold tabular-nums text-foreground">{scoreValue}</span>
             </div>
 
+            {(progressSlot || countersSlot) && (
+              <>
+                <Separator />
+                <div className="flex flex-col gap-1.5">
+                  {progressSlot}
+                  {countersSlot}
+                </div>
+              </>
+            )}
+
             {pauseSlot && (
               <>
                 <Separator />
@@ -176,6 +192,8 @@ export function ChallengeSidebar({
             <span className="font-display font-bold text-foreground tabular-nums">{scoreValue}</span>
             <span>{scoreLabel}</span>
           </div>
+          {progressSlot}
+          {countersSlot}
         </div>
         <div className="flex items-center gap-3">
           {pauseSlot}

--- a/app/src/components/challenges/GauntletMode.tsx
+++ b/app/src/components/challenges/GauntletMode.tsx
@@ -67,6 +67,18 @@ export function GauntletMode({ questions }: GauntletModeProps) {
       timerSlot={<TimerBar timeRemaining={frozen ? timeLimitSeconds : timeRemaining} timeLimitSeconds={timeLimitSeconds} />}
       scoreLabel={tChallenges("score")}
       scoreValue={state.correct}
+      progressSlot={
+        <div className="flex items-center justify-between text-[12px] text-muted-foreground tabular-nums">
+          <span>{tChallenges("progress")}</span>
+          <span className="font-bold text-foreground">{state.correct + state.wrong} / {state.questions.length}</span>
+        </div>
+      }
+      countersSlot={
+        <div className="flex items-center justify-between text-[12px] tabular-nums">
+          <span className="text-emerald-500 font-bold">✓ {state.correct}</span>
+          <span className="text-destructive font-bold">✗ {state.wrong}</span>
+        </div>
+      }
       pauseSlot={
         state.phase !== "paused" && !frozen ? (
           <PauseButton

--- a/app/src/components/challenges/TimeTrialMode.tsx
+++ b/app/src/components/challenges/TimeTrialMode.tsx
@@ -75,18 +75,30 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
         <div className="flex items-center gap-2.5 justify-center">
           {totalGained > 0 && (
             <span className="text-[12px] font-bold tabular-nums text-emerald-500">
-              +{totalGained}s
+              +{formatTimeDelta(totalGained)}
             </span>
           )}
           {totalLost > 0 && (
             <span className="text-[12px] font-bold tabular-nums text-destructive">
-              −{totalLost}s
+              −{formatTimeDelta(totalLost)}
             </span>
           )}
         </div>
       }
       scoreLabel={tChallenges("score")}
       scoreValue={state.correct}
+      progressSlot={
+        <div className="flex items-center justify-between text-[12px] text-muted-foreground tabular-nums">
+          <span>{tChallenges("progress")}</span>
+          <span className="font-bold text-foreground">{state.correct + state.wrong} / {state.questions.length}</span>
+        </div>
+      }
+      countersSlot={
+        <div className="flex items-center justify-between text-[12px] tabular-nums">
+          <span className="text-emerald-500 font-bold">✓ {state.correct}</span>
+          <span className="text-destructive font-bold">✗ {state.wrong}</span>
+        </div>
+      }
       pauseSlot={
         state.phase !== "paused" && !frozen ? (
           <PauseButton
@@ -315,6 +327,17 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
       </div>
     </div>
   );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Format seconds as "Xm Ys" when ≥ 60, otherwise "Xs". */
+function formatTimeDelta(seconds: number): string {
+  const abs = Math.abs(seconds);
+  if (abs < 60) return `${abs}s`;
+  const m = Math.floor(abs / 60);
+  const s = abs % 60;
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
 }
 
 // ── Floating delta popup ───────────────────────────────────────────


### PR DESCRIPTION
## Changes

**Both Gauntlet & Time Trial:**
- Question progress indicator (answered / total) in sidebar
- Correct (✓) / Incorrect (✗) counters, color-coded

**Time Trial only:**
- Cumulative +/- time formatted as `Xm Ys` when ≥60s (e.g. `2m 15s` instead of `135s`)

### Files changed
- `ChallengeSidebar.tsx` — new `progressSlot` + `countersSlot` props
- `GauntletMode.tsx` — passes progress + counters
- `TimeTrialMode.tsx` — passes progress + counters + `formatTimeDelta` helper
- `en.json` — added `progress` i18n key