### PR TITLE
ci: enable auto-merge for translation PRs

### DIFF
--- a/.github/workflows/auto-translate-ui.yml
+++ b/.github/workflows/auto-translate-ui.yml
@@ -84,3 +84,5 @@ jobs:
             --body "This PR updates UI translations for all locales based on changes to \`app/messages/en.json\` from commit ${{ github.sha }}." \
             --base main \
             --head i18n/auto-translate-ui-${{ github.sha }}
+
+          gh pr merge --auto --squash i18n/auto-translate-ui-${{ github.sha }}

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -75,3 +75,5 @@ jobs:
             --body "This PR updates translations for recently changed content from commit ${{ github.sha }}." \
             --base main \
             --head i18n/auto-translate-${{ github.sha }}
+
+          gh pr merge --auto --squash i18n/auto-translate-${{ github.sha }}


### PR DESCRIPTION
Adds `gh pr merge --auto --squash` to both translation workflows so PRs auto-merge once checks pass.

**Workflows updated:**
- `auto-translate.yml` (question file translations)
- `auto-translate-ui.yml` (UI string translations)

**Manual setup still required:**
1. Enable *Allow auto-merge* in repo settings
2. Create a branch ruleset on `main` requiring status checks: `pre-commit`, `spell-check`, `unit-tests`, `build`
3. Verify the GitHub App has `Contents:write` + `Pull requests:write` permissions