### PR TITLE
Refactor: consolidate game over screens, reduce button clutter

### DIFF
--- a/app/src/components/challenges/ChallengeResults.tsx
+++ b/app/src/components/challenges/ChallengeResults.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * ChallengeResults — shared end-of-run results screen for challenge modes.
+ *
+ * Accepts mode-specific config (icon, tiers, translations) so Gauntlet
+ * and Time Trial can reuse the same layout without duplication.
+ */
+
+import { useState, useEffect, type ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import type { ChallengeResult } from "@/types/challenges";
+import { useCountUp } from "@/hooks/useCountUp";
+import { cn } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RotateCcw, ArrowLeft, Trophy } from "lucide-react";
+import Link from "next/link";
+
+export interface Tier {
+  emoji: string;
+  title: string;
+  color: string;
+  bg: string;
+  border: string;
+  glow: boolean;
+}
+
+export interface ChallengeResultsProps {
+  result: ChallengeResult;
+  onRestart: () => void;
+  saveAction?: ReactNode;
+  /** Hero icon shown in the top badge */
+  icon: LucideIcon;
+  /** Tailwind bg class for the icon container */
+  iconBg: string;
+  /** Tailwind text class for the icon */
+  iconColor: string;
+  /** Tier resolved from score */
+  tier: Tier;
+  /** Large number displayed as the headline stat */
+  heroValue: number;
+  /** Label beneath the hero number */
+  heroLabel: string;
+  /** Stat card labels — [correct, wrong, accuracy] */
+  statLabels: [string, string, string];
+  /** Button / link labels */
+  playAgainLabel: string;
+  viewLeaderboardLabel: string;
+  backLabel: string;
+  /** Locale for building links */
+  locale: string;
+  /** Leaderboard tab query param, e.g. "gauntlet" or "time-trial" */
+  leaderboardTab: string;
+}
+
+export function ChallengeResults({
+  result,
+  onRestart,
+  saveAction,
+  icon: Icon,
+  iconBg,
+  iconColor,
+  tier,
+  heroValue,
+  heroLabel,
+  statLabels,
+  playAgainLabel,
+  viewLeaderboardLabel,
+  backLabel,
+  locale,
+  leaderboardTab,
+}: ChallengeResultsProps) {
+  const animatedHero = useCountUp(heroValue);
+  const total = result.correct + result.wrong;
+  const accuracy = total > 0 ? Math.round((result.correct / total) * 100) : 0;
+
+  const [showStats, setShowStats] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setShowStats(true), 600);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="max-w-[520px] mx-auto motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-500">
+      <Card className={cn("border-[1.5px] shadow-sm overflow-hidden relative", tier.glow && "shadow-lg")}>
+        {/* Decorative top stripe */}
+        <div className={cn("h-1.5 w-full", tier.bg)} />
+
+        <CardContent className="p-8 sm:p-10">
+          {/* Tier icon + title */}
+          <div className="flex flex-col items-center mb-6">
+            <div className={cn("size-20 rounded-2xl flex items-center justify-center mb-4", iconBg)}>
+              <Icon className={cn("size-10", iconColor)} />
+            </div>
+            <div className="text-center">
+              <span className="text-2xl">{tier.emoji}</span>
+              <h2 className="font-display text-[22px] sm:text-[26px] font-extrabold tracking-tight text-foreground mt-1">
+                {tier.title}
+              </h2>
+            </div>
+          </div>
+
+          {/* Hero score */}
+          <div className="text-center mb-8">
+            <div className={cn("font-display text-[64px] sm:text-[72px] font-extrabold leading-none tabular-nums", tier.color)}>
+              {animatedHero}
+            </div>
+            <div className="text-[14px] text-muted-foreground mt-1 font-medium">
+              {heroLabel}
+            </div>
+          </div>
+
+          {/* Stat cards */}
+          <div className={cn(
+            "grid grid-cols-3 gap-3 mb-8 transition-all duration-500",
+            showStats ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
+          )}>
+            <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 p-3 text-center">
+              <div className="font-display text-[22px] font-extrabold text-emerald-600 tabular-nums">
+                {result.correct}
+              </div>
+              <div className="text-[11px] font-semibold text-emerald-600/70 uppercase tracking-wide">
+                {statLabels[0]}
+              </div>
+            </div>
+            <div className="rounded-xl bg-destructive/10 border border-destructive/20 p-3 text-center">
+              <div className="font-display text-[22px] font-extrabold text-destructive tabular-nums">
+                {result.wrong}
+              </div>
+              <div className="text-[11px] font-semibold text-destructive/70 uppercase tracking-wide">
+                {statLabels[1]}
+              </div>
+            </div>
+            <div className="rounded-xl bg-muted border border-border p-3 text-center">
+              <div className="font-display text-[22px] font-extrabold text-foreground tabular-nums">
+                {accuracy}%
+              </div>
+              <div className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide">
+                {statLabels[2]}
+              </div>
+            </div>
+          </div>
+
+          {/* Save action slot */}
+          {saveAction && <div className="mb-4">{saveAction}</div>}
+
+          {/* Actions: single primary CTA + inline secondary links */}
+          <div className="flex flex-col gap-2">
+            <Button
+              onClick={onRestart}
+              className="w-full rounded-[9px] text-[14px] font-semibold bg-foreground text-card hover:bg-foreground/90"
+            >
+              <RotateCcw data-icon="inline-start" className="size-4" />
+              {playAgainLabel}
+            </Button>
+
+            <div className="flex items-center justify-center gap-1">
+              <Button
+                render={<Link href={`/${locale}/challenges/leaderboard?tab=${leaderboardTab}`} />}
+                nativeButton={false}
+                variant="ghost"
+                className="rounded-[9px] text-[13px] font-medium text-muted-foreground hover:text-foreground"
+              >
+                <Trophy data-icon="inline-start" className="size-3.5" />
+                {viewLeaderboardLabel}
+              </Button>
+
+              <span className="text-muted-foreground/30 text-xs select-none">·</span>
+
+              <Button
+                render={<Link href={`/${locale}/challenges`} />}
+                nativeButton={false}
+                variant="ghost"
+                className="rounded-[9px] text-[13px] font-medium text-muted-foreground hover:text-foreground"
+              >
+                <ArrowLeft data-icon="inline-start" className="size-3.5" />
+                {backLabel}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/src/components/challenges/GauntletResults.tsx
+++ b/app/src/components/challenges/GauntletResults.tsx
@@ -3,19 +3,15 @@
 /**
  * GauntletResults — end-of-run results screen for Gauntlet.
  *
- * Performance-tiered with fun titles, stat breakdown, and
- * celebratory visuals for high scores.
+ * Thin wrapper around ChallengeResults with Gauntlet-specific
+ * tier thresholds, icon, and translation namespace.
  */
 
-import { useState, useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import type { ChallengeResult } from "@/types/challenges";
-import { useCountUp } from "@/hooks/useCountUp";
-import { cn } from "@/lib/utils";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Heart, RotateCcw, ArrowLeft, Trophy } from "lucide-react";
-import Link from "next/link";
+import { Heart } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
+import { ChallengeResults, type Tier } from "@/components/challenges/ChallengeResults";
 
 interface GauntletResultsProps {
   result: ChallengeResult;
@@ -23,11 +19,11 @@ interface GauntletResultsProps {
   saveAction?: ReactNode;
 }
 
-function getTier(streak: number) {
+function getTier(streak: number): Tier {
   if (streak >= 50) return { emoji: "🏆", title: "resultLegendary", color: "text-amber-500", bg: "bg-amber-500/10", border: "border-amber-500/30", glow: true };
   if (streak >= 30) return { emoji: "🔥", title: "resultUnstoppable", color: "text-orange-500", bg: "bg-orange-500/10", border: "border-orange-500/30", glow: true };
   if (streak >= 15) return { emoji: "⚡", title: "resultOnFire", color: "text-primary", bg: "bg-primary/10", border: "border-primary/30", glow: false };
-  if (streak >= 5) return { emoji: "💪", title: "resultSolid", color: "text-emerald-500", bg: "bg-emerald-500/10", border: "border-emerald-500/30", glow: false };
+  if (streak >= 5)  return { emoji: "💪", title: "resultSolid", color: "text-emerald-500", bg: "bg-emerald-500/10", border: "border-emerald-500/30", glow: false };
   return { emoji: "💀", title: "resultTough", color: "text-muted-foreground", bg: "bg-muted", border: "border-border", glow: false };
 }
 
@@ -35,113 +31,29 @@ export function GauntletResults({ result, onRestart, saveAction }: GauntletResul
   const locale = useLocale();
   const t = useTranslations("Gauntlet");
   const tChallenges = useTranslations("Challenges");
-  const animatedStreak = useCountUp(result.correct);
   const tier = getTier(result.correct);
-  const accuracy = result.correct + result.wrong > 0
-    ? Math.round((result.correct / (result.correct + result.wrong)) * 100)
-    : 0;
-
-  // Delayed entrance for stats
-  const [showStats, setShowStats] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setShowStats(true), 600);
-    return () => clearTimeout(timer);
-  }, []);
 
   return (
-    <div className="max-w-[520px] mx-auto motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-500">
-      <Card className={cn("border-[1.5px] shadow-sm overflow-hidden relative", tier.glow && "shadow-lg")}>
-        {/* Decorative top stripe */}
-        <div className={cn("h-1.5 w-full", tier.bg)} />
-
-        <CardContent className="p-8 sm:p-10">
-          {/* Tier icon + title */}
-          <div className="flex flex-col items-center mb-6">
-            <div className="size-20 rounded-2xl flex items-center justify-center mb-4 bg-destructive/10">
-              <Heart className="size-10 text-destructive" />
-            </div>
-            <div className="text-center">
-              <span className="text-2xl">{tier.emoji}</span>
-              <h2 className="font-display text-[22px] sm:text-[26px] font-extrabold tracking-tight text-foreground mt-1">
-                {t(tier.title)}
-              </h2>
-            </div>
-          </div>
-
-          {/* Big streak number */}
-          <div className="text-center mb-8">
-            <div className={cn("font-display text-[64px] sm:text-[72px] font-extrabold leading-none tabular-nums", tier.color)}>
-              {animatedStreak}
-            </div>
-            <div className="text-[14px] text-muted-foreground mt-1 font-medium">
-              {t("questionsSurvived")}
-            </div>
-          </div>
-
-          {/* Stat cards */}
-          <div className={cn(
-            "grid grid-cols-3 gap-3 mb-8 transition-all duration-500",
-            showStats ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
-          )}>
-            <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-emerald-600 tabular-nums">
-                {result.correct}
-              </div>
-              <div className="text-[11px] font-semibold text-emerald-600/70 uppercase tracking-wide">
-                {t("correctCount", { count: result.correct }).replace(String(result.correct), "").trim()}
-              </div>
-            </div>
-            <div className="rounded-xl bg-destructive/10 border border-destructive/20 p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-destructive tabular-nums">
-                {result.wrong}
-              </div>
-              <div className="text-[11px] font-semibold text-destructive/70 uppercase tracking-wide">
-                {t("wrongCount", { count: result.wrong }).replace(String(result.wrong), "").trim()}
-              </div>
-            </div>
-            <div className="rounded-xl bg-muted border border-border p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-foreground tabular-nums">
-                {accuracy}%
-              </div>
-              <div className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide">
-                {t("accuracy")}
-              </div>
-            </div>
-          </div>
-
-          {/* Save action slot */}
-          {saveAction}
-
-          {/* Action buttons */}
-          <div className="flex flex-col gap-2.5">
-            <Button
-              onClick={onRestart}
-              className="w-full rounded-[9px] text-[14px] font-semibold bg-foreground text-card hover:bg-foreground/90"
-            >
-              <RotateCcw data-icon="inline-start" className="size-4" />
-              {t("playAgain")}
-            </Button>
-            <Button
-              render={<Link href={`/${locale}/challenges/leaderboard?tab=gauntlet`} />}
-              nativeButton={false}
-              variant="outline"
-              className="w-full rounded-[9px] text-[14px] font-semibold"
-            >
-              <Trophy data-icon="inline-start" className="size-4" />
-              {tChallenges("viewLeaderboard")}
-            </Button>
-            <Button
-              render={<Link href={`/${locale}/challenges`} />}
-              nativeButton={false}
-              variant="outline"
-              className="w-full rounded-[9px] text-[14px] font-semibold"
-            >
-              <ArrowLeft data-icon="inline-start" className="size-4" />
-              {t("backToChallenges")}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <ChallengeResults
+      result={result}
+      onRestart={onRestart}
+      saveAction={saveAction}
+      icon={Heart}
+      iconBg="bg-destructive/10"
+      iconColor="text-destructive"
+      tier={{ ...tier, title: t(tier.title) }}
+      heroValue={result.correct}
+      heroLabel={t("questionsSurvived")}
+      statLabels={[
+        t("correctCount", { count: result.correct }).replace(String(result.correct), "").trim(),
+        t("wrongCount", { count: result.wrong }).replace(String(result.wrong), "").trim(),
+        t("accuracy"),
+      ]}
+      playAgainLabel={t("playAgain")}
+      viewLeaderboardLabel={tChallenges("viewLeaderboard")}
+      backLabel={t("backToChallenges")}
+      locale={locale}
+      leaderboardTab="gauntlet"
+    />
   );
 }

--- a/app/src/components/challenges/TimeTrialResults.tsx
+++ b/app/src/components/challenges/TimeTrialResults.tsx
@@ -3,19 +3,15 @@
 /**
  * TimeTrialResults — end-of-run results screen for Time Trial.
  *
- * Performance-tiered with fun titles, stat breakdown, and
- * celebratory visuals for high scores.
+ * Thin wrapper around ChallengeResults with Time Trial-specific
+ * tier thresholds, icon, and translation namespace.
  */
 
-import { useState, useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import type { ChallengeResult } from "@/types/challenges";
-import { useCountUp } from "@/hooks/useCountUp";
-import { cn } from "@/lib/utils";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Timer, RotateCcw, ArrowLeft, Trophy } from "lucide-react";
-import Link from "next/link";
+import { Timer } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
+import { ChallengeResults, type Tier } from "@/components/challenges/ChallengeResults";
 
 interface TimeTrialResultsProps {
   result: ChallengeResult;
@@ -23,11 +19,11 @@ interface TimeTrialResultsProps {
   saveAction?: ReactNode;
 }
 
-function getTier(correct: number) {
+function getTier(correct: number): Tier {
   if (correct >= 50) return { emoji: "🏆", title: "resultLegendary", color: "text-amber-500", bg: "bg-amber-500/10", border: "border-amber-500/30", glow: true };
   if (correct >= 35) return { emoji: "🔥", title: "resultBlaze", color: "text-orange-500", bg: "bg-orange-500/10", border: "border-orange-500/30", glow: true };
   if (correct >= 18) return { emoji: "⚡", title: "resultQuick", color: "text-primary", bg: "bg-primary/10", border: "border-primary/30", glow: false };
-  if (correct >= 8) return { emoji: "⏱️", title: "resultSteady", color: "text-emerald-500", bg: "bg-emerald-500/10", border: "border-emerald-500/30", glow: false };
+  if (correct >= 8)  return { emoji: "⏱️", title: "resultSteady", color: "text-emerald-500", bg: "bg-emerald-500/10", border: "border-emerald-500/30", glow: false };
   return { emoji: "⏰", title: "resultOutOfTime", color: "text-muted-foreground", bg: "bg-muted", border: "border-border", glow: false };
 }
 
@@ -35,112 +31,25 @@ export function TimeTrialResults({ result, onRestart, saveAction }: TimeTrialRes
   const locale = useLocale();
   const t = useTranslations("TimeTrial");
   const tChallenges = useTranslations("Challenges");
-  const animatedCorrect = useCountUp(result.correct);
-  const total = result.correct + result.wrong;
   const tier = getTier(result.correct);
-  const accuracy = total > 0 ? Math.round((result.correct / total) * 100) : 0;
-
-  // Delayed entrance for stats
-  const [showStats, setShowStats] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setShowStats(true), 600);
-    return () => clearTimeout(timer);
-  }, []);
 
   return (
-    <div className="max-w-[520px] mx-auto motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-500">
-      <Card className={cn("border-[1.5px] shadow-sm overflow-hidden relative", tier.glow && "shadow-lg")}>
-        {/* Decorative top stripe */}
-        <div className={cn("h-1.5 w-full", tier.bg)} />
-
-        <CardContent className="p-8 sm:p-10">
-          {/* Tier icon + title */}
-          <div className="flex flex-col items-center mb-6">
-            <div className="size-20 rounded-2xl flex items-center justify-center mb-4 bg-primary/10">
-              <Timer className="size-10 text-primary" />
-            </div>
-            <div className="text-center">
-              <span className="text-2xl">{tier.emoji}</span>
-              <h2 className="font-display text-[22px] sm:text-[26px] font-extrabold tracking-tight text-foreground mt-1">
-                {t(tier.title)}
-              </h2>
-            </div>
-          </div>
-
-          {/* Big score number */}
-          <div className="text-center mb-8">
-            <div className={cn("font-display text-[64px] sm:text-[72px] font-extrabold leading-none tabular-nums", tier.color)}>
-              {animatedCorrect}
-            </div>
-            <div className="text-[14px] text-muted-foreground mt-1 font-medium">
-              {t("questionsAnswered")}
-            </div>
-          </div>
-
-          {/* Stat cards */}
-          <div className={cn(
-            "grid grid-cols-3 gap-3 mb-8 transition-all duration-500",
-            showStats ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
-          )}>
-            <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-emerald-600 tabular-nums">
-                {result.correct}
-              </div>
-              <div className="text-[11px] font-semibold text-emerald-600/70 uppercase tracking-wide">
-                {t("correct")}
-              </div>
-            </div>
-            <div className="rounded-xl bg-destructive/10 border border-destructive/20 p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-destructive tabular-nums">
-                {result.wrong}
-              </div>
-              <div className="text-[11px] font-semibold text-destructive/70 uppercase tracking-wide">
-                {t("wrong")}
-              </div>
-            </div>
-            <div className="rounded-xl bg-muted border border-border p-3 text-center">
-              <div className="font-display text-[22px] font-extrabold text-foreground tabular-nums">
-                {accuracy}%
-              </div>
-              <div className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wide">
-                {t("accuracy")}
-              </div>
-            </div>
-          </div>
-
-          {/* Save action slot */}
-          {saveAction}
-
-          {/* Actions */}
-          <div className="flex flex-col gap-2.5">
-            <Button
-              onClick={onRestart}
-              className="w-full rounded-[9px] text-[14px] font-semibold bg-foreground text-card hover:bg-foreground/90"
-            >
-              <RotateCcw data-icon="inline-start" className="size-4" />
-              {t("playAgain")}
-            </Button>
-            <Button
-              render={<Link href={`/${locale}/challenges/leaderboard?tab=time-trial`} />}
-              nativeButton={false}
-              variant="outline"
-              className="w-full rounded-[9px] text-[14px] font-semibold"
-            >
-              <Trophy data-icon="inline-start" className="size-4" />
-              {tChallenges("viewLeaderboard")}
-            </Button>
-            <Button
-              render={<Link href={`/${locale}/challenges`} />}
-              nativeButton={false}
-              variant="outline"
-              className="w-full rounded-[9px] text-[14px] font-semibold"
-            >
-              <ArrowLeft data-icon="inline-start" className="size-4" />
-              {t("backToChallenges")}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <ChallengeResults
+      result={result}
+      onRestart={onRestart}
+      saveAction={saveAction}
+      icon={Timer}
+      iconBg="bg-primary/10"
+      iconColor="text-primary"
+      tier={{ ...tier, title: t(tier.title) }}
+      heroValue={result.correct}
+      heroLabel={t("questionsAnswered")}
+      statLabels={[t("correct"), t("wrong"), t("accuracy")]}
+      playAgainLabel={t("playAgain")}
+      viewLeaderboardLabel={tChallenges("viewLeaderboard")}
+      backLabel={t("backToChallenges")}
+      locale={locale}
+      leaderboardTab="time-trial"
+    />
   );
 }


### PR DESCRIPTION
## Problem
Both challenge game over screens (Gauntlet + Time Trial) stack up to 4 full-width buttons vertically — feels heavy and cluttered, especially on mobile.

## Changes

### Button layout declutter
- **Play Again** remains sole full-width primary CTA
- **View Leaderboard** and **Back to Challenges** moved to a side-by-side row of `ghost` buttons beneath — lighter visual weight, less vertical stacking

### Save slot spacing
- Added `mb-4` wrapper around the save action slot so status text / sign-in CTA doesn't crowd the action buttons

### Deduplication
- Extracted shared `ChallengeResults` component (~170 lines) housing layout, stat grid, animations, and button group
- `GauntletResults` and `TimeTrialResults` now thin ~55-line wrappers passing mode-specific config (icon, tiers, translations)

## Before → After (button area)
```
BEFORE:                          AFTER:
┌────────────────────┐           ┌────────────────────┐
│    Play Again      │           │    Play Again      │
├────────────────────┤           └────────────────────┘
│  View Leaderboard  │             Leaderboard · Back
├────────────────────┤
│ Back to Challenges │
└────────────────────┘
```
