### PR TITLE
fix: align challenge breadcrumbs with game content width

### DIFF
--- a/app/src/app/[locale]/challenges/gauntlet/page.tsx
+++ b/app/src/app/[locale]/challenges/gauntlet/page.tsx
@@ -40,7 +40,7 @@ export default async function GauntletPage({ params }: Props) {
   return (
     <div>
       {/* Breadcrumb */}
-      <div className="max-w-[800px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
         <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
           <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
             {t("label")}

--- a/app/src/app/[locale]/challenges/time-trial/page.tsx
+++ b/app/src/app/[locale]/challenges/time-trial/page.tsx
@@ -41,7 +41,7 @@ export default async function TimeTrialPage({ params }: Props) {
   return (
     <div>
       {/* Breadcrumb */}
-      <div className="max-w-[800px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
         <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
           <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
             {tChallenges("label")}


### PR DESCRIPTION
## Problem
Breadcrumbs on gauntlet and time-trial pages used `max-w-[800px]` while game content uses `max-w-[1200px]`, causing visual misalignment.

## Fix
Changed both breadcrumb containers to `max-w-[1200px]` to match the game content width — consistent with how Quiz and Questions pages handle breadcrumbs.

## Files changed
- `app/src/app/[locale]/challenges/gauntlet/page.tsx`
- `app/src/app/[locale]/challenges/time-trial/page.tsx`