### PR TITLE
refactor: extract shared PageBreadcrumb using shadcn/ui

### DIFF
--- a/app/src/app/[locale]/challenges/gauntlet/page.tsx
+++ b/app/src/app/[locale]/challenges/gauntlet/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { getAllQuestions, getCertCatalog, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
-import Link from "next/link";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { GauntletMode } from "@/components/challenges/GauntletMode";
 
 interface Props {
@@ -39,15 +39,13 @@ export default async function GauntletPage({ params }: Props) {
 
   return (
     <div>
-      {/* Breadcrumb */}
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
-            {t("label")}
-          </Link>
-          <span>›</span>
-          <span>{t("gauntletMode")}</span>
-        </div>
+        <PageBreadcrumb
+          items={[
+            { label: t("label"), href: `/${locale}/challenges` },
+            { label: t("gauntletMode") },
+          ]}
+        />
       </div>
 
       <GauntletMode questions={questions} />

--- a/app/src/app/[locale]/challenges/time-trial/page.tsx
+++ b/app/src/app/[locale]/challenges/time-trial/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { getAllQuestions, getCertCatalog, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
-import Link from "next/link";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { TimeTrialMode } from "@/components/challenges/TimeTrialMode";
 
 interface Props {
@@ -40,15 +40,13 @@ export default async function TimeTrialPage({ params }: Props) {
 
   return (
     <div>
-      {/* Breadcrumb */}
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
-            {tChallenges("label")}
-          </Link>
-          <span>›</span>
-          <span>{t("title")}</span>
-        </div>
+        <PageBreadcrumb
+          items={[
+            { label: tChallenges("label"), href: `/${locale}/challenges` },
+            { label: t("title") },
+          ]}
+        />
       </div>
 
       <TimeTrialMode questions={questions} />

--- a/app/src/app/[locale]/questions/[cert]/page.tsx
+++ b/app/src/app/[locale]/questions/[cert]/page.tsx
@@ -5,8 +5,8 @@
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import type { CertificationType } from "@/lib/questions";
 import { getQuestionsByCert, getCertInfo, SUPPORTED_LOCALES, CERT_TITLES, VALID_CERTS, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
@@ -58,11 +58,13 @@ export default async function CertQuestionsPage({ params }: Props) {
 
   return (
     <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-12 sm:py-20">
-      <div className="flex items-center gap-2 text-[13px] text-muted-foreground mb-4">
-        <Link href={`/${locale}/practice-tests`} className="text-primary no-underline hover:underline">{t("label")}</Link>
-        <span>›</span>
-        <span>{certInfo.title}</span>
-      </div>
+      <PageBreadcrumb
+        className="mb-4"
+        items={[
+          { label: t("label"), href: `/${locale}/practice-tests` },
+          { label: certInfo.title },
+        ]}
+      />
       <h1 className="font-display text-[30px] font-extrabold text-foreground tracking-tight">
         {certInfo.title}
       </h1>

--- a/app/src/components/PageBreadcrumb.tsx
+++ b/app/src/components/PageBreadcrumb.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+interface BreadcrumbSegment {
+  label: string;
+  /** If provided, renders as a link. Last item should omit href. */
+  href?: string;
+}
+
+interface PageBreadcrumbProps {
+  items: BreadcrumbSegment[];
+  className?: string;
+}
+
+/**
+ * Shared breadcrumb nav used across practice-test, question, and challenge pages.
+ * Wraps shadcn Breadcrumb with consistent styling and Next.js Link integration.
+ */
+export function PageBreadcrumb({ items, className }: PageBreadcrumbProps) {
+  const nodes: ReactNode[] = [];
+
+  items.forEach((item, i) => {
+    const isLast = i === items.length - 1;
+
+    if (i > 0) {
+      nodes.push(<BreadcrumbSeparator key={`sep-${i}`}>›</BreadcrumbSeparator>);
+    }
+
+    nodes.push(
+      <BreadcrumbItem key={item.label}>
+        {item.href && !isLast ? (
+          <BreadcrumbLink
+            render={<Link href={item.href} />}
+            className="text-primary no-underline hover:underline hover:text-primary"
+          >
+            {item.label}
+          </BreadcrumbLink>
+        ) : (
+          <BreadcrumbPage className="font-normal text-muted-foreground">
+            {item.label}
+          </BreadcrumbPage>
+        )}
+      </BreadcrumbItem>,
+    );
+  });
+
+  return (
+    <Breadcrumb className={className}>
+      <BreadcrumbList className="text-[13px] gap-2">
+        {nodes}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/app/src/components/quiz/Quiz.tsx
+++ b/app/src/components/quiz/Quiz.tsx
@@ -14,9 +14,9 @@ import { useState, useCallback, useEffect } from "react";
 import { Question } from "@/types/quiz";
 import { shuffle, cn } from "@/lib/utils";
 import { useCountUp } from "@/hooks/useCountUp";
-import Link from "next/link";
-import { useLocale, useTranslations } from "next-intl";
 import { localePath } from "@/lib/locales";
+import { useLocale, useTranslations } from "next-intl";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -201,11 +201,13 @@ export function Quiz({ questions, questionCount, cert, certName }: QuizProps) {
     <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-6 sm:py-12">
       {/* Top bar with breadcrumb */}
       <div className="mb-6 sm:mb-9">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground mb-1">
-          <Link href={localePath(locale, "/practice-tests")} className="text-primary no-underline hover:underline">{t("breadcrumbPracticeTests")}</Link>
-          <span>›</span>
-          <span>{certName}</span>
-        </div>
+        <PageBreadcrumb
+          className="mb-1"
+          items={[
+            { label: t("breadcrumbPracticeTests"), href: localePath(locale, "/practice-tests") },
+            { label: certName },
+          ]}
+        />
         <h1 className="font-display text-[24px] sm:text-[30px] font-extrabold text-foreground tracking-tight">{certName}</h1>
       </div>
 

--- a/app/src/components/ui/breadcrumb.tsx
+++ b/app/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "breadcrumb-link",
+    },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? (
+        <ChevronRightIcon />
+      )}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}


### PR DESCRIPTION
## What
Replace 4 duplicated inline breadcrumb markups with a shared `PageBreadcrumb` component built on shadcn/ui Breadcrumb primitives.

## Why
- **Accessibility:** Adds semantic `<nav aria-label="breadcrumb">` and `aria-current="page"` — previously missing
- **DRY:** Single source of truth for breadcrumb styling instead of 4 copy-pasted blocks
- **Consistency:** All breadcrumbs now use identical markup, separators, and link styling

## Changes
- **New** `app/src/components/ui/breadcrumb.tsx` — shadcn Breadcrumb primitives
- **New** `app/src/components/PageBreadcrumb.tsx` — thin wrapper accepting `items` array
- **Updated** 4 files to use `PageBreadcrumb`:
  - `components/quiz/Quiz.tsx`
  - `app/[locale]/questions/[cert]/page.tsx`
  - `app/[locale]/challenges/gauntlet/page.tsx`
  - `app/[locale]/challenges/time-trial/page.tsx`

## Verification
- ✅ `npm run build` passes
- ✅ All 4227 tests pass