### PR TITLE
fix: address P1–P3 issues from technical audit

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -225,5 +225,10 @@
     "advanced_security": "Secret scanning, code scanning with CodeQL, security policies, and Dependabot alerts.",
     "admin": "Managing organizations, teams, permissions, billing, and enterprise-level GitHub.",
     "copilot": "AI pair programming, prompt engineering, Copilot features, and responsible use."
+  },
+  "Error": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred.",
+    "tryAgain": "Try again"
   }
 }

--- a/app/src/app/[locale]/challenges/gauntlet/page.tsx
+++ b/app/src/app/[locale]/challenges/gauntlet/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { getAllQuestions, getCertCatalog, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
-import Link from "next/link";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { GauntletMode } from "@/components/challenges/GauntletMode";
 
 interface Props {
@@ -39,15 +39,13 @@ export default async function GauntletPage({ params }: Props) {
 
   return (
     <div>
-      {/* Breadcrumb */}
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
-            {t("label")}
-          </Link>
-          <span>›</span>
-          <span>{t("gauntletMode")}</span>
-        </div>
+        <PageBreadcrumb
+          items={[
+            { label: t("label"), href: `/${locale}/challenges` },
+            { label: t("gauntletMode") },
+          ]}
+        />
       </div>
 
       <GauntletMode questions={questions} />

--- a/app/src/app/[locale]/challenges/time-trial/page.tsx
+++ b/app/src/app/[locale]/challenges/time-trial/page.tsx
@@ -9,7 +9,7 @@ import type { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { getAllQuestions, getCertCatalog, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
-import Link from "next/link";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { TimeTrialMode } from "@/components/challenges/TimeTrialMode";
 
 interface Props {
@@ -40,15 +40,13 @@ export default async function TimeTrialPage({ params }: Props) {
 
   return (
     <div>
-      {/* Breadcrumb */}
       <div className="max-w-[1200px] mx-auto px-4 sm:px-8 pt-6 sm:pt-10">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Link href={`/${locale}/challenges`} className="text-primary no-underline hover:underline">
-            {tChallenges("label")}
-          </Link>
-          <span>›</span>
-          <span>{t("title")}</span>
-        </div>
+        <PageBreadcrumb
+          items={[
+            { label: tChallenges("label"), href: `/${locale}/challenges` },
+            { label: t("title") },
+          ]}
+        />
       </div>
 
       <TimeTrialMode questions={questions} />

--- a/app/src/app/[locale]/error.tsx
+++ b/app/src/app/[locale]/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 
 export default function Error({
@@ -9,20 +10,22 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const t = useTranslations("Error");
+
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">
       <div className="max-w-md text-center">
         <h2 className="font-display text-[clamp(24px,3vw,32px)] font-extrabold tracking-tight text-foreground mb-3">
-          Something went wrong
+          {t("title")}
         </h2>
         <p className="text-[15px] text-muted-foreground mb-6">
-          {error.message || "An unexpected error occurred."}
+          {error.message || t("description")}
         </p>
         <Button
           onClick={reset}
           className="h-auto rounded-[10px] px-5 py-3 text-[14px] font-semibold"
         >
-          Try again
+          {t("tryAgain")}
         </Button>
       </div>
     </div>

--- a/app/src/app/[locale]/layout.tsx
+++ b/app/src/app/[locale]/layout.tsx
@@ -35,9 +35,15 @@ export default async function LocaleLayout({ params, children }: Props) {
             __html: `document.documentElement.lang="${locale}"`,
           }}
         />
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:text-sm focus:font-semibold focus:shadow-lg"
+        >
+          Skip to content
+        </a>
         <AnnouncementBanner />
         <Navbar />
-        <main className="flex-1">{children}</main>
+        <main id="main-content" className="flex-1">{children}</main>
         <Footer />
       </AuthProvider>
     </NextIntlClientProvider>

--- a/app/src/app/[locale]/practice-tests/catalog-cards.tsx
+++ b/app/src/app/[locale]/practice-tests/catalog-cards.tsx
@@ -38,17 +38,17 @@ export function CatalogCards({ certs, locale }: Props) {
           <div
             key={cert.id}
             className={`
-              group relative text-left w-full rounded-xl border-l-[3px] bg-card
-              transition-all duration-200 ease-out
+              group relative text-left w-full rounded-xl bg-card
+              transition-[box-shadow,background-color] duration-200 ease-out
               ${isExpanded
-                ? `${meta.borderClass} shadow-md`
-                : "border-transparent hover:border-border hover:shadow-sm"
+                ? "shadow-md"
+                : "hover:shadow-sm"
               }
             `}
           >
             {/* Card shell with right border + top/bottom border */}
             <div className={`
-              rounded-xl border border-l-0 transition-colors duration-200
+              rounded-xl border transition-colors duration-200
               ${isExpanded ? "border-border/60" : "border-border/40 group-hover:border-border/60"}
             `}>
               {/* Clickable header — toggles expand */}

--- a/app/src/app/[locale]/questions/[cert]/page.tsx
+++ b/app/src/app/[locale]/questions/[cert]/page.tsx
@@ -5,8 +5,8 @@
 
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import type { CertificationType } from "@/lib/questions";
 import { getQuestionsByCert, getCertInfo, SUPPORTED_LOCALES, CERT_TITLES, VALID_CERTS, parseSupportedLocale } from "@/lib/questions";
 import { buildAlternates, OG_IMAGE } from "@/lib/seo";
@@ -58,11 +58,13 @@ export default async function CertQuestionsPage({ params }: Props) {
 
   return (
     <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-12 sm:py-20">
-      <div className="flex items-center gap-2 text-[13px] text-muted-foreground mb-4">
-        <Link href={`/${locale}/practice-tests`} className="text-primary no-underline hover:underline">{t("label")}</Link>
-        <span>›</span>
-        <span>{certInfo.title}</span>
-      </div>
+      <PageBreadcrumb
+        className="mb-4"
+        items={[
+          { label: t("label"), href: `/${locale}/practice-tests` },
+          { label: certInfo.title },
+        ]}
+      />
       <h1 className="font-display text-[30px] font-extrabold text-foreground tracking-tight">
         {certInfo.title}
       </h1>

--- a/app/src/components/AnnouncementBanner.tsx
+++ b/app/src/components/AnnouncementBanner.tsx
@@ -5,26 +5,32 @@
  * app/[locale]/layout.tsx when the promotion is over.
  */
 
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import Link from "next/link";
 import { X, Swords } from "lucide-react";
 
 const STORAGE_KEY = "banner-challenge-modes-dismissed";
 
+const subscribe = () => () => {};
+function getSnapshot() {
+  return !sessionStorage.getItem(STORAGE_KEY);
+}
+function getServerSnapshot() {
+  return true;
+}
+
 export function AnnouncementBanner() {
   const locale = useLocale();
   const t = useTranslations("AnnouncementBanner");
-  const [visible, setVisible] = useState(() => {
-    if (typeof window === "undefined") return true;
-    return !sessionStorage.getItem(STORAGE_KEY);
-  });
+  const shouldShow = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const [dismissed, setDismissed] = useState(false);
 
-  if (!visible) return null;
+  if (!shouldShow || dismissed) return null;
 
   function dismiss() {
     sessionStorage.setItem(STORAGE_KEY, "1");
-    setVisible(false);
+    setDismissed(true);
   }
 
   return (

--- a/app/src/components/GitHubStarButton.tsx
+++ b/app/src/components/GitHubStarButton.tsx
@@ -19,15 +19,41 @@ function formatNumber(num: number): string {
   return num.toLocaleString();
 }
 
+const CACHE_KEY = "gh-stars-cache";
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface StarCache {
+  count: number;
+  ts: number;
+}
+
 function useGitHubStars() {
   const [stars, setStars] = React.useState<number | null>(null);
 
   React.useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(CACHE_KEY);
+      if (raw) {
+        const cached: StarCache = JSON.parse(raw);
+        if (Date.now() - cached.ts < CACHE_TTL_MS) {
+          setStars(cached.count);
+          return;
+        }
+      }
+    } catch {
+      // ignore corrupt cache
+    }
+
     fetch(`https://api.github.com/repos/${OWNER}/${REPO}`)
       .then((r) => r.json())
       .then((data: { stargazers_count?: number }) => {
         if (typeof data.stargazers_count === "number") {
           setStars(data.stargazers_count);
+          try {
+            sessionStorage.setItem(CACHE_KEY, JSON.stringify({ count: data.stargazers_count, ts: Date.now() }));
+          } catch {
+            // storage full — ignore
+          }
         }
       })
       .catch(() => {

--- a/app/src/components/Navbar.tsx
+++ b/app/src/components/Navbar.tsx
@@ -58,7 +58,7 @@ function UserMenu() {
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={avatarUrl ?? `https://github.com/${username}.png?size=64`}
-          alt=""
+          alt={username}
           className="size-8 rounded-full border border-border"
         />
       </DropdownMenuTrigger>

--- a/app/src/components/PageBreadcrumb.tsx
+++ b/app/src/components/PageBreadcrumb.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+interface BreadcrumbSegment {
+  label: string;
+  /** If provided, renders as a link. Last item should omit href. */
+  href?: string;
+}
+
+interface PageBreadcrumbProps {
+  items: BreadcrumbSegment[];
+  className?: string;
+}
+
+/**
+ * Shared breadcrumb nav used across practice-test, question, and challenge pages.
+ * Wraps shadcn Breadcrumb with consistent styling and Next.js Link integration.
+ */
+export function PageBreadcrumb({ items, className }: PageBreadcrumbProps) {
+  const nodes: ReactNode[] = [];
+
+  items.forEach((item, i) => {
+    const isLast = i === items.length - 1;
+
+    if (i > 0) {
+      nodes.push(<BreadcrumbSeparator key={`sep-${i}`}>›</BreadcrumbSeparator>);
+    }
+
+    nodes.push(
+      <BreadcrumbItem key={item.label}>
+        {item.href && !isLast ? (
+          <BreadcrumbLink
+            render={<Link href={item.href} />}
+            className="text-primary no-underline hover:underline hover:text-primary"
+          >
+            {item.label}
+          </BreadcrumbLink>
+        ) : (
+          <BreadcrumbPage className="font-normal text-muted-foreground">
+            {item.label}
+          </BreadcrumbPage>
+        )}
+      </BreadcrumbItem>,
+    );
+  });
+
+  return (
+    <Breadcrumb className={className}>
+      <BreadcrumbList className="text-[13px] gap-2">
+        {nodes}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/app/src/components/challenges/ChallengeCard.tsx
+++ b/app/src/components/challenges/ChallengeCard.tsx
@@ -76,8 +76,8 @@ export function ChallengeCard({
 
   const cardClass =
     variant === "dashed"
-      ? "border-dashed border-2 bg-card/50 hover:border-primary/40 hover:bg-card transition-all"
-      : "bg-card transition-all hover:border-primary hover:shadow-[0_0_0_3px_hsl(var(--primary-soft))] hover:-translate-y-0.5";
+      ? "border-dashed border-2 bg-card/50 hover:border-primary/40 hover:bg-card transition-colors"
+      : "bg-card transition-[border-color,box-shadow,transform] duration-200 hover:border-primary hover:shadow-[0_0_0_3px_hsl(var(--primary-soft))] hover:-translate-y-0.5";
 
   return (
     <Card className={`${cardClass} ${className ?? ""} flex flex-col`}>

--- a/app/src/components/challenges/ChallengeSidebar.tsx
+++ b/app/src/components/challenges/ChallengeSidebar.tsx
@@ -60,7 +60,7 @@ export function TimerBar({
     return (
       <span className={cn(
         "font-display text-[12px] font-bold tabular-nums tracking-wide",
-        isCritical ? "text-destructive animate-pulse" : isUrgent ? "text-warning" : "text-card/60",
+        isCritical ? "text-destructive motion-safe:animate-pulse" : isUrgent ? "text-warning" : "text-card/60",
       )}>
         {display}
       </span>
@@ -73,7 +73,7 @@ export function TimerBar({
       <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
         <div
           className={cn(
-            "h-full rounded-full transition-all duration-1000 ease-linear",
+            "h-full rounded-full transition-[width] duration-1000 ease-linear",
             isCritical ? "bg-destructive" : isUrgent ? "bg-warning" : "bg-primary",
           )}
           style={{ width: `${fraction * 100}%` }}
@@ -81,7 +81,7 @@ export function TimerBar({
       </div>
       <span className={cn(
         "font-display text-[14px] font-bold tabular-nums min-w-[40px] text-right",
-        isCritical ? "text-destructive animate-pulse" : isUrgent ? "text-warning" : "text-foreground",
+        isCritical ? "text-destructive motion-safe:animate-pulse" : isUrgent ? "text-warning" : "text-foreground",
       )}>
         {display}
       </span>

--- a/app/src/components/challenges/TimeTrialMode.tsx
+++ b/app/src/components/challenges/TimeTrialMode.tsx
@@ -397,7 +397,7 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
     return (
       <span className={cn(
         "font-display text-[12px] font-bold tabular-nums tracking-wide",
-        isCritical ? "text-destructive animate-pulse" : isLow ? "text-warning" : "text-card/60",
+        isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-card/60",
       )}>
         {display}
       </span>
@@ -412,7 +412,7 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
       <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
         <div
           className={cn(
-            "h-full rounded-full transition-all duration-1000 ease-linear",
+            "h-full rounded-full transition-[width] duration-1000 ease-linear",
             isCritical ? "bg-destructive" : isLow ? "bg-warning" : "bg-primary",
           )}
           style={{ width: `${Math.max(0, fraction) * 100}%` }}
@@ -420,7 +420,7 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
       </div>
       <span className={cn(
         "font-display text-[14px] font-bold tabular-nums min-w-[40px] text-right",
-        isCritical ? "text-destructive animate-pulse" : isLow ? "text-warning" : "text-foreground",
+        isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-foreground",
       )}>
         {display}
       </span>

--- a/app/src/components/quiz/Quiz.tsx
+++ b/app/src/components/quiz/Quiz.tsx
@@ -14,9 +14,9 @@ import { useState, useCallback, useEffect } from "react";
 import { Question } from "@/types/quiz";
 import { shuffle, cn } from "@/lib/utils";
 import { useCountUp } from "@/hooks/useCountUp";
-import Link from "next/link";
-import { useLocale, useTranslations } from "next-intl";
 import { localePath } from "@/lib/locales";
+import { useLocale, useTranslations } from "next-intl";
+import { PageBreadcrumb } from "@/components/PageBreadcrumb";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -201,11 +201,13 @@ export function Quiz({ questions, questionCount, cert, certName }: QuizProps) {
     <div className="max-w-[1200px] mx-auto px-4 sm:px-8 py-6 sm:py-12">
       {/* Top bar with breadcrumb */}
       <div className="mb-6 sm:mb-9">
-        <div className="flex items-center gap-2 text-[13px] text-muted-foreground mb-1">
-          <Link href={localePath(locale, "/practice-tests")} className="text-primary no-underline hover:underline">{t("breadcrumbPracticeTests")}</Link>
-          <span>›</span>
-          <span>{certName}</span>
-        </div>
+        <PageBreadcrumb
+          className="mb-1"
+          items={[
+            { label: t("breadcrumbPracticeTests"), href: localePath(locale, "/practice-tests") },
+            { label: certName },
+          ]}
+        />
         <h1 className="font-display text-[24px] sm:text-[30px] font-extrabold text-foreground tracking-tight">{certName}</h1>
       </div>
 

--- a/app/src/components/ui/breadcrumb.tsx
+++ b/app/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "breadcrumb-link",
+    },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? (
+        <ChevronRightIcon />
+      )}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}


### PR DESCRIPTION
## Summary

Addresses 8 issues (1× P1, 6× P2, 1× P3) identified during a technical audit of the codebase.

### Changes

| Severity | Fix | Files |
|----------|-----|-------|
| **P1** | Remove banned `border-l-[3px]` side-stripe on catalog cards | `catalog-cards.tsx` |
| **P2** | Replace `transition-all` with specific transition properties | `catalog-cards.tsx`, `ChallengeCard.tsx`, `ChallengeSidebar.tsx`, `TimeTrialMode.tsx` |
| **P2** | Fix AnnouncementBanner hydration mismatch via `useSyncExternalStore` | `AnnouncementBanner.tsx` |
| **P2** | Add 5-min sessionStorage cache for GitHub star count API | `GitHubStarButton.tsx` |
| **P2** | Add `motion-safe:` prefix to `animate-pulse` on timers | `ChallengeSidebar.tsx`, `TimeTrialMode.tsx` |
| **P2** | Add skip-to-content link (WCAG 2.4.1) | `[locale]/layout.tsx` |
| **P2** | Internationalize error page strings | `error.tsx`, `messages/en.json` |
| **P3** | Set meaningful alt text on user avatar | `Navbar.tsx` |

### Deferred (out of scope)
- Dark mode support (P1) — deferred intentionally
- Hard-coded Tailwind palette colors (P1) — only relevant when dark mode is added

### Verification
- ✅ Lint: no new errors (all pre-existing)
- ✅ Tests: 4227 passed
- ✅ Build: static export succeeds