### PR TITLE
refactor: consolidate cross-locale tests from 4227 to 75

### DIFF
--- a/app/src/lib/__tests__/cross-locale.test.ts
+++ b/app/src/lib/__tests__/cross-locale.test.ts
@@ -62,45 +62,46 @@ describe("cross-locale consistency", () => {
       if (localeQuestions.size === 0) continue;
 
       describe(`${locale}/${cert}`, () => {
-        for (const [qId, localeQ] of localeQuestions) {
-          const enQ = enQuestions.get(qId);
-          if (!enQ) continue; // translated question without English source — skip
+        it("all questions match English answer structure", () => {
+          for (const [qId, localeQ] of localeQuestions) {
+            const enQ = enQuestions.get(qId);
+            if (!enQ) continue;
 
-          it(`${qId} matches English answer structure`, () => {
-            // Same number of answers
             expect(
               localeQ.answers.length,
-              `answer count mismatch`,
+              `${qId} answer count mismatch`,
             ).toBe(enQ.answers.length);
 
-            // Same correct/incorrect pattern
             const enPattern = enQ.answers.map((a) => a.isCorrect);
             const localePattern = localeQ.answers.map((a) => a.isCorrect);
             expect(
               localePattern,
-              `correct/incorrect pattern mismatch`,
+              `${qId} correct/incorrect pattern mismatch`,
             ).toEqual(enPattern);
-          });
+          }
+        });
 
-          it(`${qId} matches English documentation link`, () => {
+        it("all questions match English documentation links", () => {
+          for (const [qId, localeQ] of localeQuestions) {
+            const enQ = enQuestions.get(qId);
+            if (!enQ) continue;
+
             const enDoc = enQ.frontmatter.documentation as string | undefined;
             const localeDoc = localeQ.frontmatter.documentation as string | undefined;
 
-            // Both must have or both must lack a documentation link
             if (enDoc && localeDoc) {
               expect(
                 localeDoc,
-                `documentation link mismatch`,
+                `${qId} documentation link mismatch`,
               ).toBe(enDoc);
             } else {
-              // If one has it the other should too
               expect(
                 !!localeDoc,
-                `documentation link presence mismatch`,
+                `${qId} documentation link presence mismatch`,
               ).toBe(!!enDoc);
             }
-          });
-        }
+          }
+        });
       });
     }
   }


### PR DESCRIPTION
## What

Consolidate per-question `it()` blocks in `cross-locale.test.ts` into per-cert-per-locale `it()` blocks, matching the pattern already used in `questions.test.ts`.

## Why

Test suite reported **4,227 tests** across only 3 files. ~4,192 came from `cross-locale.test.ts` generating 2 `it()` per question × 4 non-English locales × 524 questions.

## Result

- **4,227 → 75 tests**, all passing
- Question IDs remain in `expect()` messages — failures still pinpoint exact question
- Only `cross-locale.test.ts` changed