### PR TITLE
test: expand test coverage for critical app flows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,7 +71,7 @@ jobs:
       - run: npm run test:e2e
         working-directory: app
       - uses: actions/upload-artifact@043fb46d1ac8dc357dfe103e980d66bb9cc66911 # v7.0.1
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         with:
           name: playwright-report
           path: app/playwright-report/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: app
       - run: npm run test:e2e
         working-directory: app
-      - uses: actions/upload-artifact@043fb46d1ac8dc357dfe103e980d66bb9cc66911 # v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:
           name: playwright-report

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: app
       - run: npm run test:e2e
         working-directory: app
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1ac8dc357dfe103e980d66bb9cc66911 # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,3 +55,24 @@ jobs:
         working-directory: app
       - run: npm run build
         working-directory: app
+  e2e-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.node-version'
+      - run: npm ci
+        working-directory: app
+      - run: npx playwright install --with-deps chromium
+        working-directory: app
+      - run: npm run test:e2e
+        working-directory: app
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: app/playwright-report/
+          retention-days: 7

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
 
 # next.js
 /.next/

--- a/app/e2e/challenge-flow.spec.ts
+++ b/app/e2e/challenge-flow.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+/** Select enough answers to enable the Confirm button. */
+async function selectAnswers(page: import("@playwright/test").Page) {
+  const radios = page.getByRole("radio");
+  const checkboxes = page.getByRole("checkbox");
+
+  if ((await radios.count()) > 0) {
+    // Single-select: pick the first radio
+    await radios.first().click();
+  } else {
+    // Multi-select: click all checkboxes to meet the required count
+    const count = await checkboxes.count();
+    for (let i = 0; i < count; i++) {
+      await checkboxes.nth(i).click();
+    }
+  }
+}
+
+test.describe("challenge modes", () => {
+  test("gauntlet mode starts and shows gameplay UI", async ({ page }) => {
+    await page.goto("/en/challenges/gauntlet/");
+    await expect(page.locator("main")).toBeVisible();
+
+    // Question/answer UI visible
+    const answerList = page
+      .getByRole("radiogroup")
+      .or(page.getByRole("group"));
+    await expect(answerList).toBeVisible({ timeout: 15_000 });
+
+    // Lives indicator — Heart SVGs rendered by LivesDisplay
+    const hearts = page.locator("svg.text-destructive.fill-destructive");
+    await expect(hearts.first()).toBeVisible();
+  });
+
+  test("gauntlet mode - can answer a question", async ({ page }) => {
+    await page.goto("/en/challenges/gauntlet/");
+
+    const answerList = page
+      .getByRole("radiogroup")
+      .or(page.getByRole("group"));
+    await expect(answerList).toBeVisible({ timeout: 15_000 });
+
+    await selectAnswers(page);
+
+    const confirmBtn = page.getByRole("button", { name: /confirm/i });
+    await expect(confirmBtn).toBeEnabled({ timeout: 5_000 });
+    await confirmBtn.click();
+
+    // After confirming the page transitions: correct → new answers, wrong → review
+    await page.waitForFunction(
+      () => {
+        const hasAnswers = document.querySelector('[role="radiogroup"], [role="group"]');
+        const hasNextBtn = [...document.querySelectorAll("button")].some((b) =>
+          /next question/i.test(b.textContent ?? ""),
+        );
+        return hasAnswers || hasNextBtn;
+      },
+      { timeout: 10_000 },
+    );
+  });
+
+  test("time trial mode starts with timer visible", async ({ page }) => {
+    // Use mobile viewport so the lg:hidden timer bar is visible
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.goto("/en/challenges/time-trial/");
+    await expect(page.locator("main")).toBeVisible();
+
+    // Question/answer UI visible
+    const answerList = page
+      .getByRole("radiogroup")
+      .or(page.getByRole("group"));
+    await expect(answerList).toBeVisible({ timeout: 15_000 });
+
+    // Timer display — tabular-nums span with time text
+    const timerText = page.locator(".tabular-nums").filter({
+      hasText: /\d+:\d{2}|\d+s/,
+    });
+    await expect(timerText.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("time trial mode - can answer a question", async ({ page }) => {
+    await page.goto("/en/challenges/time-trial/");
+
+    const answerList = page
+      .getByRole("radiogroup")
+      .or(page.getByRole("group"));
+    await expect(answerList).toBeVisible({ timeout: 15_000 });
+
+    await selectAnswers(page);
+
+    const confirmBtn = page.getByRole("button", { name: /confirm/i });
+    await expect(confirmBtn).toBeEnabled({ timeout: 5_000 });
+    await confirmBtn.click();
+
+    // Wait for page transition after confirming
+    await page.waitForFunction(
+      () => {
+        const hasAnswers = document.querySelector('[role="radiogroup"], [role="group"]');
+        const hasNextBtn = [...document.querySelectorAll("button")].some((b) =>
+          /next question/i.test(b.textContent ?? ""),
+        );
+        return hasAnswers || hasNextBtn;
+      },
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/app/e2e/quiz-flow.spec.ts
+++ b/app/e2e/quiz-flow.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("quiz flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/en/practice-tests/foundations");
+    // Wait for quiz to hydrate (skeleton disappears, answer options appear)
+    await page.getByRole("radiogroup", { name: /answer options/i }).or(
+      page.getByRole("group", { name: /answer options/i })
+    ).first().waitFor({ timeout: 15_000 });
+  });
+
+  test("can see question with answer options", async ({ page }) => {
+    // Question header visible (e.g. "Question 1 of N")
+    await expect(page.getByText(/question 1 of \d+/i)).toBeVisible();
+
+    // Answer group present
+    const answerGroup = page.getByRole("radiogroup", { name: /answer options/i }).or(
+      page.getByRole("group", { name: /answer options/i })
+    ).first();
+    await expect(answerGroup).toBeVisible();
+
+    // At least 2 answer options
+    const options = answerGroup.getByRole("radio").or(answerGroup.getByRole("checkbox"));
+    await expect(options).toHaveCount(await options.count());
+    expect(await options.count()).toBeGreaterThanOrEqual(2);
+  });
+
+  test("can select an answer and navigate next", async ({ page }) => {
+    // Select first answer option
+    const answerGroup = page.getByRole("radiogroup", { name: /answer options/i }).or(
+      page.getByRole("group", { name: /answer options/i })
+    ).first();
+    const firstOption = answerGroup.getByRole("radio").or(answerGroup.getByRole("checkbox")).first();
+    await firstOption.click();
+
+    // Verify it's selected
+    await expect(firstOption).toHaveAttribute("aria-checked", "true");
+
+    // Click "Next question" button (exact to avoid matching "Next question page")
+    await page.getByRole("button", { name: "Next question", exact: true }).click();
+
+    // Verify we moved to question 2
+    await expect(page.getByText(/question 2 of \d+/i)).toBeVisible();
+  });
+
+  test("can navigate between questions", async ({ page }) => {
+    // Select an answer on question 1
+    const getAnswerGroup = () =>
+      page.getByRole("radiogroup", { name: /answer options/i }).or(
+        page.getByRole("group", { name: /answer options/i })
+      ).first();
+
+    await getAnswerGroup().getByRole("radio").or(getAnswerGroup().getByRole("checkbox")).first().click();
+
+    // Go to question 2
+    await page.getByRole("button", { name: "Next question", exact: true }).click();
+    await expect(page.getByText(/question 2 of \d+/i)).toBeVisible();
+
+    // Go back to question 1
+    await page.getByRole("button", { name: "Previous", exact: true }).click();
+    await expect(page.getByText(/question 1 of \d+/i)).toBeVisible();
+
+    // Go forward again
+    await page.getByRole("button", { name: "Next question", exact: true }).click();
+    await expect(page.getByText(/question 2 of \d+/i)).toBeVisible();
+  });
+
+  test("can submit quiz and see results", async ({ page }) => {
+    // Use ?questions=3 to limit quiz length for faster test
+    await page.goto("/en/practice-tests/foundations?questions=3");
+    await page.getByRole("radiogroup", { name: /answer options/i }).or(
+      page.getByRole("group", { name: /answer options/i })
+    ).first().waitFor({ timeout: 15_000 });
+
+    // Answer 3 questions
+    for (let i = 0; i < 3; i++) {
+      const answerGroup = page.getByRole("radiogroup", { name: /answer options/i }).or(
+        page.getByRole("group", { name: /answer options/i })
+      ).first();
+      const radios = answerGroup.getByRole("radio");
+      const checkboxes = answerGroup.getByRole("checkbox");
+
+      if (await checkboxes.count() > 0) {
+        await checkboxes.first().click();
+      } else {
+        await radios.first().click();
+      }
+
+      if (i < 2) {
+        await page.getByRole("button", { name: "Next question", exact: true }).click();
+        await expect(page.getByText(new RegExp(`question ${i + 2} of 3`, "i"))).toBeVisible();
+      }
+    }
+
+    // On last question, click "Submit Exam"
+    await page.getByRole("button", { name: /submit exam/i }).first().click();
+
+    // Confirmation dialog — click "Submit Exam"
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: /submit exam/i }).click();
+
+    // Results section appears with score
+    await expect(page.getByText(/results/i).first()).toBeVisible();
+    await expect(page.getByText(/\d+ of 3 correct/i)).toBeVisible();
+  });
+});

--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+test("landing page loads", async ({ page }) => {
+  await page.goto("/en/");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.locator("h1")).toBeVisible();
+  await expect(page.getByRole("link", { name: /practice test/i })).toBeVisible();
+});
+
+test("practice tests list loads", async ({ page }) => {
+  await page.goto("/en/practice-tests/");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.locator("h2")).toBeVisible();
+  await expect(page.locator("h3").first()).toBeVisible();
+});
+
+test("individual practice test loads", async ({ page }) => {
+  await page.goto("/en/practice-tests/foundations");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(
+    page.getByRole("radiogroup").or(page.getByRole("group")),
+  ).toBeVisible();
+});
+
+test("challenge hub loads", async ({ page }) => {
+  await page.goto("/en/challenges/");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.getByText(/gauntlet/i).first()).toBeVisible();
+  await expect(page.getByText(/time trial/i).first()).toBeVisible();
+});
+
+test("leaderboard page loads", async ({ page }) => {
+  await page.goto("/en/challenges/leaderboard/");
+  await expect(page.locator("main")).toBeVisible();
+  await expect(page.getByRole("heading", { name: /leaderboard/i })).toBeVisible();
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,12 +26,16 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.2.3",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4",
         "typescript": "^6",
         "vitest": "^4.1.4"
@@ -66,6 +70,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -535,6 +590,159 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
@@ -977,6 +1185,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2385,6 +2611,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@primer/octicons-react": {
       "version": "19.24.1",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.24.1.tgz",
@@ -3355,6 +3597,64 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -3404,6 +3704,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4519,6 +4826,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -5006,6 +5323,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5039,6 +5370,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -5122,6 +5467,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -5238,6 +5590,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5268,6 +5630,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.4.1",
@@ -5352,6 +5721,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6949,6 +7331,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7494,6 +7889,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7762,6 +8164,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -8272,6 +8725,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8290,6 +8753,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdquiz": {
       "version": "0.1.1",
@@ -9196,6 +9666,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9277,6 +9760,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/po-parser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
@@ -9355,6 +9885,51 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -9829,6 +10404,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -10576,6 +11164,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -10749,6 +11344,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10990,6 +11598,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11360,6 +11978,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -11367,6 +11998,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -11597,6 +12263,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",
@@ -31,12 +32,16 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.2.3",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4",
     "typescript": "^6",
     "vitest": "^4.1.4"

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/app/src/components/AnnouncementBanner.tsx
+++ b/app/src/components/AnnouncementBanner.tsx
@@ -52,7 +52,7 @@ export function AnnouncementBanner() {
           e.preventDefault();
           dismiss();
         }}
-        className="touch-target absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md text-card/70 hover:text-card transition-colors"
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-3 rounded-md text-card/70 hover:text-card transition-colors"
         aria-label={t("dismiss")}
       >
         <X className="size-4" />

--- a/app/src/hooks/__tests__/useGauntletMode.test.ts
+++ b/app/src/hooks/__tests__/useGauntletMode.test.ts
@@ -229,6 +229,57 @@ describe("useGauntletMode", () => {
     expect(hook.result.current.pauseRequested).toBe(false);
   });
 
+  it("answering all questions correctly reaches completed phase with result", async () => {
+    // Use only 3 questions so we can exhaust the pool
+    const shortPool = questions.slice(0, 3);
+    const hook = renderHook(() => useGauntletMode(shortPool, {}));
+    await act(async () => {});
+
+    for (let i = 0; i < 3; i++) {
+      const { correctId } = answerIds(hook);
+      act(() => { hook.result.current.toggleAnswer(correctId); });
+      act(() => { hook.result.current.confirmAnswer(); });
+      expect(hook.result.current.state.phase).toBe("feedback");
+      act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+    }
+
+    expect(hook.result.current.state.phase).toBe("completed");
+    expect(hook.result.current.state.correct).toBe(3);
+    expect(hook.result.current.state.wrong).toBe(0);
+    expect(hook.result.current.result).not.toBeNull();
+    expect(hook.result.current.result!.correct).toBe(3);
+  });
+
+  it("pause during wrong_review pauses on continue", async () => {
+    const hook = await setup();
+    const { wrongId } = answerIds(hook);
+
+    act(() => { hook.result.current.toggleAnswer(wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("wrong_review");
+
+    // Request pause while in wrong_review (togglePause only works in playing/feedback,
+    // so request it before answering wrong — but we need to test the continueAfterWrong path)
+    // Actually togglePause guards: playing | feedback. So we request pause before answering.
+    // Let's redo: start fresh, request pause during playing, then answer wrong.
+    const hook2 = await setup();
+    act(() => { hook2.result.current.togglePause(); });
+    expect(hook2.result.current.pauseRequested).toBe(true);
+
+    const ids2 = answerIds(hook2);
+    act(() => { hook2.result.current.toggleAnswer(ids2.wrongId); });
+    act(() => { hook2.result.current.confirmAnswer(); });
+    expect(hook2.result.current.state.phase).toBe("wrong_review");
+
+    // Continue should go to paused (not playing) since pause was requested
+    act(() => { hook2.result.current.continueAfterWrong(); });
+    expect(hook2.result.current.state.phase).toBe("paused");
+
+    // Resume
+    act(() => { hook2.result.current.togglePause(); });
+    expect(hook2.result.current.state.phase).toBe("playing");
+  });
+
   it("timeout on last life leads to game_over_review", async () => {
     const hook = await setup({ lives: 1 });
 

--- a/app/src/hooks/__tests__/useGauntletMode.test.ts
+++ b/app/src/hooks/__tests__/useGauntletMode.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useGauntletMode } from "@/hooks/useGauntletMode";
+import type { Question } from "@/types/quiz";
+
+const makeQuestion = (id: string, correctId: string, wrongId: string): Question => ({
+  id,
+  cert: "foundations",
+  question: `Question ${id}`,
+  answers: [
+    { id: correctId, text: "Correct", isCorrect: true },
+    { id: wrongId, text: "Wrong", isCorrect: false },
+  ],
+  isMultiSelect: false,
+});
+
+const questions = [
+  makeQuestion("q1", "a1", "b1"),
+  makeQuestion("q2", "a2", "b2"),
+  makeQuestion("q3", "a3", "b3"),
+  makeQuestion("q4", "a4", "b4"),
+  makeQuestion("q5", "a5", "b5"),
+];
+
+const CORRECT_ADVANCE_DELAY = 1200;
+
+describe("useGauntletMode", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Helper: render hook and wait for mount effect (loading → playing). */
+  async function setup(opts = {}) {
+    const hook = renderHook(() => useGauntletMode(questions, opts));
+    // Let the mount useEffect fire (shuffles questions, sets phase to "playing")
+    await act(async () => {});
+    return hook;
+  }
+
+  /** Get correct/wrong answer IDs for current question. */
+  function answerIds(hook: ReturnType<typeof renderHook<ReturnType<typeof useGauntletMode>, unknown>>) {
+    const q = hook.result.current.currentQuestion!;
+    return {
+      correctId: q.answers.find((a) => a.isCorrect)!.id,
+      wrongId: q.answers.find((a) => !a.isCorrect)!.id,
+    };
+  }
+
+  it("transitions to playing after mount with correct initial state", async () => {
+    const { result } = await setup();
+
+    expect(result.current.state.phase).toBe("playing");
+    expect(result.current.state.lives).toBe(3);
+    expect(result.current.state.initialLives).toBe(3);
+    expect(result.current.state.correct).toBe(0);
+    expect(result.current.state.wrong).toBe(0);
+    expect(result.current.currentQuestion).not.toBeNull();
+    expect(result.current.state.questions).toHaveLength(questions.length);
+  });
+
+  it("correct answer increments score and advances after delay", async () => {
+    const hook = await setup();
+    const { correctId } = answerIds(hook);
+
+    act(() => { hook.result.current.toggleAnswer(correctId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+
+    expect(hook.result.current.state.phase).toBe("feedback");
+    expect(hook.result.current.state.correct).toBe(1);
+    expect(hook.result.current.state.lastAnswerCorrect).toBe(true);
+
+    // Advance past CORRECT_ADVANCE_DELAY to auto-advance
+    act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+
+    expect(hook.result.current.state.phase).toBe("playing");
+    expect(hook.result.current.state.currentIndex).toBe(1);
+  });
+
+  it("wrong answer decrements lives and enters wrong_review", async () => {
+    const hook = await setup();
+    const { wrongId } = answerIds(hook);
+
+    act(() => { hook.result.current.toggleAnswer(wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+
+    expect(hook.result.current.state.phase).toBe("wrong_review");
+    expect(hook.result.current.state.lives).toBe(2);
+    expect(hook.result.current.state.wrong).toBe(1);
+    expect(hook.result.current.state.lastAnswerCorrect).toBe(false);
+
+    // Continue to next question
+    act(() => { hook.result.current.continueAfterWrong(); });
+
+    expect(hook.result.current.state.phase).toBe("playing");
+    expect(hook.result.current.state.currentIndex).toBe(1);
+  });
+
+  it("game over after all lives lost", async () => {
+    const hook = await setup();
+
+    // Lose life 1
+    let ids = answerIds(hook);
+    act(() => { hook.result.current.toggleAnswer(ids.wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("wrong_review");
+    expect(hook.result.current.state.lives).toBe(2);
+    act(() => { hook.result.current.continueAfterWrong(); });
+
+    // Lose life 2
+    ids = answerIds(hook);
+    act(() => { hook.result.current.toggleAnswer(ids.wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("wrong_review");
+    expect(hook.result.current.state.lives).toBe(1);
+    act(() => { hook.result.current.continueAfterWrong(); });
+
+    // Lose life 3 — last life
+    ids = answerIds(hook);
+    act(() => { hook.result.current.toggleAnswer(ids.wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("game_over_review");
+    expect(hook.result.current.state.lives).toBe(0);
+    expect(hook.result.current.state.wrong).toBe(3);
+
+    // Proceed to results
+    act(() => { hook.result.current.proceedToResults(); });
+    expect(hook.result.current.state.phase).toBe("game_over");
+    expect(hook.result.current.result).not.toBeNull();
+    expect(hook.result.current.result!.wrong).toBe(3);
+  });
+
+  it("timeout counts as wrong answer", async () => {
+    const hook = await setup();
+
+    expect(hook.result.current.state.phase).toBe("playing");
+    const livesBefore = hook.result.current.state.lives;
+
+    // Advance 60 seconds (default timeLimitSeconds)
+    act(() => { vi.advanceTimersByTime(60 * 1000); });
+
+    expect(hook.result.current.state.lives).toBe(livesBefore - 1);
+    expect(hook.result.current.state.wrong).toBe(1);
+    expect(hook.result.current.failedByTimeout).toBe(true);
+  });
+
+  it("restart resets state to initial values", async () => {
+    const hook = await setup();
+
+    // Answer one correct
+    let ids = answerIds(hook);
+    act(() => { hook.result.current.toggleAnswer(ids.correctId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+
+    // Answer one wrong
+    ids = answerIds(hook);
+    act(() => { hook.result.current.toggleAnswer(ids.wrongId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    act(() => { hook.result.current.continueAfterWrong(); });
+
+    expect(hook.result.current.state.correct).toBe(1);
+    expect(hook.result.current.state.wrong).toBe(1);
+    expect(hook.result.current.state.lives).toBe(2);
+
+    // Restart
+    act(() => { hook.result.current.restart(); });
+
+    expect(hook.result.current.state.phase).toBe("playing");
+    expect(hook.result.current.state.correct).toBe(0);
+    expect(hook.result.current.state.wrong).toBe(0);
+    expect(hook.result.current.state.lives).toBe(3);
+    expect(hook.result.current.state.currentIndex).toBe(0);
+  });
+
+  it("multi-select: partial selection treated as wrong", async () => {
+    // Only pass multi-select questions so shuffle doesn't matter
+    const multiQs: Question[] = [{
+      id: "mq1",
+      cert: "foundations",
+      question: "Pick two",
+      answers: [
+        { id: "ma1", text: "A", isCorrect: true },
+        { id: "ma2", text: "B", isCorrect: true },
+        { id: "ma3", text: "C", isCorrect: false },
+      ],
+      isMultiSelect: true,
+    }];
+
+    const hook = renderHook(() => useGauntletMode(multiQs, {}));
+    await act(async () => {});
+
+    const q = hook.result.current.currentQuestion!;
+    expect(q.isMultiSelect).toBe(true);
+    const oneCorrectId = q.answers.find((a) => a.isCorrect)!.id;
+
+    // Select only 1 of 2 correct — should not be complete
+    act(() => { hook.result.current.toggleAnswer(oneCorrectId); });
+    expect(hook.result.current.isAnswerComplete()).toBe(false);
+
+    // Confirm should be a no-op since answer is incomplete
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("playing");
+  });
+
+  it("pause queues between questions", async () => {
+    const hook = await setup();
+    const { correctId } = answerIds(hook);
+
+    // Request pause during playing
+    act(() => { hook.result.current.togglePause(); });
+    expect(hook.result.current.pauseRequested).toBe(true);
+
+    // Answer correctly — after feedback delay should pause instead of advance
+    act(() => { hook.result.current.toggleAnswer(correctId); });
+    act(() => { hook.result.current.confirmAnswer(); });
+    expect(hook.result.current.state.phase).toBe("feedback");
+
+    act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+    expect(hook.result.current.state.phase).toBe("paused");
+
+    // Resume from pause
+    act(() => { hook.result.current.togglePause(); });
+    expect(hook.result.current.state.phase).toBe("playing");
+    expect(hook.result.current.pauseRequested).toBe(false);
+  });
+
+  it("timeout on last life leads to game_over_review", async () => {
+    const hook = await setup({ lives: 1 });
+
+    expect(hook.result.current.state.lives).toBe(1);
+
+    // Let timeout fire
+    act(() => { vi.advanceTimersByTime(60 * 1000); });
+
+    expect(hook.result.current.state.phase).toBe("game_over_review");
+    expect(hook.result.current.state.lives).toBe(0);
+    expect(hook.result.current.failedByTimeout).toBe(true);
+
+    act(() => { hook.result.current.proceedToResults(); });
+    expect(hook.result.current.state.phase).toBe("game_over");
+    expect(hook.result.current.result).not.toBeNull();
+  });
+});

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  useTimeTrialMode,
+  INITIAL_TIME,
+  CORRECT_BONUS,
+  WRONG_PENALTY,
+} from "@/hooks/useTimeTrialMode";
+import type { Question } from "@/types/quiz";
+
+const makeQuestion = (id: string, correctId: string, wrongId: string): Question => ({
+  id,
+  cert: "foundations",
+  question: `Question ${id}`,
+  answers: [
+    { id: correctId, text: "Correct", isCorrect: true },
+    { id: wrongId, text: "Wrong", isCorrect: false },
+  ],
+  isMultiSelect: false,
+});
+
+const questions = [
+  makeQuestion("q1", "a1", "b1"),
+  makeQuestion("q2", "a2", "b2"),
+  makeQuestion("q3", "a3", "b3"),
+  makeQuestion("q4", "a4", "b4"),
+  makeQuestion("q5", "a5", "b5"),
+];
+
+function getCorrectId(hook: ReturnType<typeof useTimeTrialMode>) {
+  return hook.currentQuestion!.answers.find((a) => a.isCorrect)!.id;
+}
+
+function getWrongId(hook: ReturnType<typeof useTimeTrialMode>) {
+  return hook.currentQuestion!.answers.find((a) => !a.isCorrect)!.id;
+}
+
+describe("useTimeTrialMode", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initializes with playing phase and correct defaults after mount", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {}); // flush mount effect
+
+    expect(result.current.state.phase).toBe("playing");
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME);
+    expect(result.current.state.correct).toBe(0);
+    expect(result.current.state.wrong).toBe(0);
+    expect(result.current.currentQuestion).not.toBeNull();
+  });
+
+  it("correct answer adds time bonus", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    const correctId = getCorrectId(result.current);
+
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.state.phase).toBe("feedback");
+    expect(result.current.state.correct).toBe(1);
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS);
+    expect(result.current.totalGained).toBe(CORRECT_BONUS);
+    expect(result.current.lastDelta).toBe(CORRECT_BONUS);
+  });
+
+  it("wrong answer subtracts time penalty", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    const wrongId = getWrongId(result.current);
+
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.state.phase).toBe("wrong_review");
+    expect(result.current.state.wrong).toBe(1);
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME - WRONG_PENALTY);
+    expect(result.current.totalLost).toBe(WRONG_PENALTY);
+    expect(result.current.lastDelta).toBe(-WRONG_PENALTY);
+  });
+
+  it("timer counts down each second", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME - 1);
+
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME - 3);
+  });
+
+  it("timer reaching 0 triggers game over", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    act(() => { vi.advanceTimersByTime(INITIAL_TIME * 1000); });
+
+    expect(result.current.state.phase).toBe("game_over");
+    expect(result.current.result).not.toBeNull();
+  });
+
+  it("continueAfterWrong advances to next question", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.state.phase).toBe("wrong_review");
+
+    const indexBefore = result.current.state.currentIndex;
+    act(() => { result.current.continueAfterWrong(); });
+
+    expect(result.current.state.phase).toBe("playing");
+    expect(result.current.state.currentIndex).toBe(indexBefore + 1);
+  });
+
+  it("restart resets all state", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Play a bit: answer wrong then continue
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+    act(() => { result.current.continueAfterWrong(); });
+
+    // Restart
+    act(() => { result.current.restart(); });
+
+    expect(result.current.state.phase).toBe("playing");
+    expect(result.current.state.correct).toBe(0);
+    expect(result.current.state.wrong).toBe(0);
+    expect(result.current.state.currentIndex).toBe(0);
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME);
+    expect(result.current.totalGained).toBe(0);
+    expect(result.current.totalLost).toBe(0);
+    expect(result.current.lastDelta).toBeNull();
+  });
+
+  it("timer stops during feedback phase", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    const correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.state.phase).toBe("feedback");
+    const timeAtFeedback = result.current.timeRemaining;
+
+    // Tick several seconds — timer should NOT change during feedback
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(result.current.timeRemaining).toBe(timeAtFeedback);
+  });
+
+  it("wrong penalty that drops time to 0 ends game on continue", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Drain time to just above penalty threshold
+    const ticksNeeded = INITIAL_TIME - WRONG_PENALTY;
+    act(() => { vi.advanceTimersByTime(ticksNeeded * 1000); });
+    expect(result.current.timeRemaining).toBe(WRONG_PENALTY);
+
+    // Wrong answer — penalty brings time to 0
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.timeRemaining).toBe(0);
+    expect(result.current.state.phase).toBe("wrong_review");
+
+    // Continue should trigger game over since time is 0
+    act(() => { result.current.continueAfterWrong(); });
+    expect(result.current.state.phase).toBe("game_over");
+    expect(result.current.result).not.toBeNull();
+  });
+
+  it("pause queues between questions", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Request pause
+    act(() => { result.current.togglePause(); });
+    expect(result.current.pauseRequested).toBe(true);
+
+    // Answer wrong — continue should pause instead of advance
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+    act(() => { result.current.continueAfterWrong(); });
+
+    expect(result.current.state.phase).toBe("paused");
+
+    // Resume
+    act(() => { result.current.togglePause(); });
+    expect(result.current.state.phase).toBe("playing");
+  });
+});

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -187,6 +187,68 @@ describe("useTimeTrialMode", () => {
     expect(result.current.result).not.toBeNull();
   });
 
+  it("exhausting all questions triggers game over", () => {
+    // Use only 2 questions
+    const shortPool = questions.slice(0, 2);
+    const { result } = renderHook(() => useTimeTrialMode(shortPool));
+    act(() => {});
+
+    // Answer question 1 correctly
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    act(() => { vi.advanceTimersByTime(1200 + 50); }); // FEEDBACK_ADVANCE_DELAY
+
+    // Answer question 2 correctly
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+
+    expect(result.current.state.phase).toBe("game_over");
+    expect(result.current.state.correct).toBe(2);
+    expect(result.current.result).not.toBeNull();
+  });
+
+  it("pause after correct answer pauses instead of advancing", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Request pause during playing
+    act(() => { result.current.togglePause(); });
+    expect(result.current.pauseRequested).toBe(true);
+
+    // Answer correctly — after feedback delay should pause
+    const correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.state.phase).toBe("feedback");
+
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    expect(result.current.state.phase).toBe("paused");
+
+    // Resume
+    act(() => { result.current.togglePause(); });
+    expect(result.current.state.phase).toBe("playing");
+    expect(result.current.pauseRequested).toBe(false);
+  });
+
+  it("timer stops during wrong_review phase", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.state.phase).toBe("wrong_review");
+    const timeAtReview = result.current.timeRemaining;
+
+    // Tick several seconds — timer should NOT change during wrong_review
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(result.current.timeRemaining).toBe(timeAtReview);
+  });
+
   it("pause queues between questions", () => {
     const { result } = renderHook(() => useTimeTrialMode(questions));
     act(() => {});

--- a/app/src/lib/__tests__/render-code-spans.test.tsx
+++ b/app/src/lib/__tests__/render-code-spans.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { renderCodeSpans } from "@/lib/render-code-spans";
+import { describe, it, expect } from "vitest";
+
+describe("renderCodeSpans", () => {
+  it("renders plain text as a span", () => {
+    const { container } = render(<>{renderCodeSpans("hello world")}</>);
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span!.textContent).toBe("hello world");
+    expect(container.querySelector("code")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("renders inline backticks as <code> with correct text", () => {
+    const { container } = render(<>{renderCodeSpans("use `git status` now")}</>);
+    const code = container.querySelector("code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toBe("git status");
+  });
+
+  it("renders fenced code block as <pre> containing <code>", () => {
+    const input = "```js\nconst x = 1;\n```";
+    const { container } = render(<>{renderCodeSpans(input)}</>);
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    const code = pre!.querySelector("code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toBe("const x = 1;");
+  });
+
+  it("renders mixed content: text + inline code + fenced block", () => {
+    const input = "Run `npm install` then:\n```sh\nnpm run build\n```\nDone.";
+    const { container } = render(<>{renderCodeSpans(input)}</>);
+
+    const hasInlineCode = Array.from(container.querySelectorAll("code")).some(
+      (el) => el.textContent === "npm install" && !el.closest("pre")
+    );
+    expect(hasInlineCode).toBe(true);
+
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre!.querySelector("code")!.textContent).toBe("npm run build");
+
+    expect(container.textContent).toContain("Run");
+    expect(container.textContent).toContain("Done.");
+  });
+
+  it("renders multiple inline code spans in one string", () => {
+    const input = "Use `foo` and `bar` together";
+    const { container } = render(<>{renderCodeSpans(input)}</>);
+    const codes = container.querySelectorAll("code");
+    expect(codes).toHaveLength(2);
+    expect(codes[0].textContent).toBe("foo");
+    expect(codes[1].textContent).toBe("bar");
+  });
+
+  it("does not leak language tag into fenced block output", () => {
+    const input = "```yaml\nkey: value\n```";
+    const { container } = render(<>{renderCodeSpans(input)}</>);
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toBe("key: value");
+    expect(code!.textContent).not.toContain("yaml");
+  });
+
+  it("handles multiple fenced blocks in one string", () => {
+    const input = "before\n```js\nfoo()\n```\nmiddle\n```py\nbar()\n```\nafter";
+    const { container } = render(<>{renderCodeSpans(input)}</>);
+    const pres = container.querySelectorAll("pre");
+    expect(pres).toHaveLength(2);
+    expect(pres[0].querySelector("code")!.textContent).toBe("foo()");
+    expect(pres[1].querySelector("code")!.textContent).toBe("bar()");
+    expect(container.textContent).toContain("before");
+    expect(container.textContent).toContain("middle");
+    expect(container.textContent).toContain("after");
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests and E2E tests for the critical paths that make or break the app.

### Unit tests (6 files, 101 tests)

| File | What it tests |
|---|---|
| `useGauntletMode.test.ts` | Lives, timeout, game over, multi-select, pause queuing, last-life timeout, restart |
| `useTimeTrialMode.test.ts` | Timer bonuses/penalties, freeze during feedback, lethal penalty→game over, pause, restart |
| `render-code-spans.test.tsx` | Inline code, fenced blocks, mixed content, multi-fence, language tag leak |
| `questions.test.ts` | *(pre-existing)* Question markdown parsing |
| `cross-locale.test.ts` | *(pre-existing)* Translation consistency |
| `utils.test.ts` | *(pre-existing)* shuffle, locale helpers |

### E2E tests (3 files, 13 Playwright tests)

| File | What it tests |
|---|---|
| `smoke.spec.ts` | Landing, practice tests, challenge hub, leaderboard pages load |
| `quiz-flow.spec.ts` | Answer question, navigate, submit quiz, see results |
| `challenge-flow.spec.ts` | Gauntlet with lives display, Time Trial with timer |

### CI

- Added `e2e-tests` job to `pr-checks.yml` — installs Chromium, runs Playwright, uploads report artifact on failure
- No Supabase needed — app gracefully degrades without it

### What we intentionally skipped

- `cn()`, `seo.ts`, locale metadata — low risk, won't break the app
- Supabase-dependent internals (`leaderboard.ts`, `save-result.ts`) — needs mock patterns first
- Dropped `challenge-result-save-policy` test after review — was just testing `>=` operator