### PR TITLE
actions/q-128: ADD question r/t Workflow firing d/t Reopened PR

### DIFF
--- a/questions/en/actions/question-128.md
+++ b/questions/en/actions/question-128.md
@@ -1,0 +1,12 @@
+---
+question: "A workflow is firing when pull requests are reopened. Why might this be the cause?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request"
+---
+
+- [x] `types: [reopened]` is defined under the `pull_request` event. 
+- [ ] Branch protection rules were improperly configured.
+> Branch protection rules do not determine when a workflow fires.
+- [x] No activity types are defined under the `pull_request` event.
+> If no activity types are explicitly defined, the `pull_request` event will fire off on opened PRs (`opened`), PRs whose source branch has been updated since the PR was opened (`synchronize`), or reopened PRs (`reopened`).
+- [ ] `on: schedule` was configured with `pull_requests: [reopened]`
+> `schedule` is used to fire workflows at certain times, not repository-based activity.

--- a/questions/en/actions/question-128.md
+++ b/questions/en/actions/question-128.md
@@ -1,5 +1,5 @@
 ---
-question: "A workflow is firing when pull requests are reopened. Why might this be the cause?"
+question: "A workflow is triggered when pull requests are reopened. Why might this be the cause?"
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request"
 ---
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
Adds a question as to why a workflow might fire when a pull request is reopened. In particular, highlights the fact that default `pull_request` activity types are `opened`, `synchronize`, and `reopened`
See supporting documentation: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request

## Related issue(s)
N/A

## Screenshots
N/A
