### PR TITLE
actions/q-129: GITHUB_TOKEN and other repos

### DIFF
--- a/questions/en/actions/question-129.md
+++ b/questions/en/actions/question-129.md
@@ -1,0 +1,10 @@
+---
+question: "`GITHUB_TOKEN` can be used to check out any repository."
+documentation: "https://docs.github.com/en/actions/concepts/security/github_token#about-the-github_token"
+---
+
+- [ ] True
+- [ ] Only with elevated permissions
+- [x] False
+> `GITHUB_TOKEN`'s permissions are scoped to the repository that contains the workflow that was triggered. 
+To check out another repository, other methods token must be used, such as a personal access token (PAT) or installation access token

--- a/questions/en/actions/question-129.md
+++ b/questions/en/actions/question-129.md
@@ -7,4 +7,4 @@ documentation: "https://docs.github.com/en/actions/concepts/security/github_toke
 - [ ] Only with elevated permissions
 - [x] False
 > `GITHUB_TOKEN`'s permissions are scoped to the repository that contains the workflow that was triggered. 
-To check out another repository, other methods token must be used, such as a personal access token (PAT) or installation access token
+> To check out another repository, other methods token must be used, such as a personal access token (PAT) or installation access token


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a question about GITHUB_TOKEN being used to check out other repositories (it can't). Helps clarify that GITHUB_TOKEN should only be used to work with the repository the workflow is defined in. 

## Related issue(s)
N/A
## Screenshots
N/A