### PR TITLE
ci: separate translation tests into label-gated workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,8 +57,11 @@ Access at `http://localhost:3000`. The dev server provides hot reload.
 ```bash
 cd app && npm run build   # production build (static export)
 cd app && npm run lint     # ESLint
-cd app && npm test         # Vitest unit tests
+cd app && npm test         # Vitest unit tests (excludes cross-locale translation tests)
+cd app && npm run test:translations  # Cross-locale translation consistency tests
 ```
+
+> **Note:** `npm test` excludes cross-locale tests by default so English source edits aren't blocked by stale translations. Translation tests run in a separate CI workflow (`translation-checks.yml`) only on PRs labeled `translations` (auto-applied when non-English question/message files change).
 
 ## Browser Testing
 Use the **agent-browser** skill for any tasks that involve browser interaction — such as testing the website, verifying UI changes, taking screenshots, checking page behavior, or any form of exploratory/automated browser testing.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,18 @@ copilot:
 - changed-files:
   - any-glob-to-any-file: "questions/en/copilot/*"
 
+translations:
+- changed-files:
+  - any-glob-to-any-file:
+    - "questions/es/**"
+    - "questions/pt/**"
+    - "questions/pl/**"
+    - "questions/ja/**"
+    - "app/messages/es.json"
+    - "app/messages/pt.json"
+    - "app/messages/pl.json"
+    - "app/messages/ja.json"
+
 documentation:
 - changed-files:
   - any-glob-to-any-file: ["README.md", "CONTRIBUTING.md"]

--- a/.github/workflows/translation-checks.yml
+++ b/.github/workflows/translation-checks.yml
@@ -1,0 +1,26 @@
+name: Translation Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ labeled, synchronize, opened ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cross-locale-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'translations')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.node-version'
+      - run: npm ci
+        working-directory: app
+      - run: npm run test:translations
+        working-directory: app

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "test:translations": "vitest run --config vitest.translations.config.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/app/vitest.translations.config.ts
+++ b/app/vitest.translations.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: ["src/**/*.test.{ts,tsx}"],
-    exclude: ["src/lib/__tests__/cross-locale.test.ts", "node_modules"],
+    include: ["src/lib/__tests__/cross-locale.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Separates cross-locale translation tests from the default `npm test` suite so that English source question edits are no longer blocked by stale translations.

### Changes

- **`app/vitest.config.ts`** — Excludes `cross-locale.test.ts` from default test run
- **`app/vitest.translations.config.ts`** (new) — Dedicated vitest config for cross-locale tests
- **`app/package.json`** — Added `test:translations` script
- **`.github/labeler.yml`** — Added `translations` label for non-English question/message paths
- **`.github/workflows/translation-checks.yml`** (new) — Runs `npm run test:translations` only on PRs labeled `translations`

### How it works

| PR type | `translations` label | `npm test` (pr-checks) | `npm run test:translations` (translation-checks) |
|---|---|---|---|
| English source edit | ❌ | ✅ runs (no cross-locale) | ⏭️ skipped |
| Auto-translate PR | ✅ (auto-applied) | ✅ runs (no cross-locale) | ✅ runs cross-locale |
| App code only | ❌ | ✅ runs (no cross-locale) | ⏭️ skipped |