### PR TITLE
Improve advanced_security question-037 clarity and distractors

### DIFF
--- a/questions/en/advanced_security/question-037.md
+++ b/questions/en/advanced_security/question-037.md
@@ -3,7 +3,10 @@ question: "What does the default CodeQL analysis setup in GitHub do?"
 documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql#about-code-scanning-with-codeql"
 ---
 
-- [x] Automatically chooses languages to analyze, query suite to run, and events that trigger scans
-- [ ] Manually requires users to specify languages and queries for each scan
-- [ ] Scans code only on a monthly basis
-- [ ] Requires separate installation of third-party scanning tools
+- [x] Automatically detects languages, selects the default query suite, and configures scan triggers
+- [ ] Requires users to select languages and define a custom query suite before scans can run
+> A confirmation dialog is shown when enabling default setup, but languages and query suite are automatically pre-selected
+- [ ] Analyzes only the repository's primary language using the extended query suite
+> Default setup scans all supported languages, not just the primary one, and uses the default query suite
+- [ ] Creates a CodeQL workflow file in the repository that must be merged before scanning begins
+> This describes the advanced setup, not the default setup


### PR DESCRIPTION
## Changes
- Refined correct answer wording for clarity
- Replaced weak distractors ("monthly scans", "third-party tools") with plausible alternatives:
  - Confusion with the setup confirmation dialog
  - Mix-up between primary vs all languages and default vs extended query suite
  - Confusion between default and advanced setup (workflow file)
- Added answer explanations, including note about the confirmation popup

Fixes #570