### PR TITLE
feat: half-life penalty for multi-select questions in Gauntlet mode

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -194,6 +194,7 @@
   "Gauntlet": {
     "correctFeedback": "Correct! Keep going!",
     "wrongLifeLost": "Wrong answer — you lost a life!",
+    "wrongHalfLifeLost": "Almost there — lost only half a life!",
     "wrongGameOver": "Wrong answer — game over!",
     "timeUpLifeLost": "Time's up — you lost a life!",
     "timeUpGameOver": "Time's up — game over!",

--- a/app/src/components/challenges/ChallengeSidebar.tsx
+++ b/app/src/components/challenges/ChallengeSidebar.tsx
@@ -22,17 +22,37 @@ export function LivesDisplay({ lives, initialLives, compact }: { lives: number; 
   const size = compact ? "size-3.5" : "size-5";
   return (
     <div className="flex items-center gap-0.5">
-      {Array.from({ length: initialLives }, (_, i) => (
-        <Heart
-          key={i}
-          className={cn(
-            size,
-            i < lives
-              ? "text-destructive fill-destructive"
-              : compact ? "text-card/20" : "text-muted-foreground/30",
-          )}
-        />
-      ))}
+      {Array.from({ length: initialLives }, (_, i) => {
+        const remaining = lives - i;
+        if (remaining >= 1) {
+          // Full heart
+          return (
+            <Heart
+              key={i}
+              className={cn(size, "text-destructive fill-destructive")}
+            />
+          );
+        }
+        if (remaining > 0) {
+          // Half heart — filled left half over empty heart
+          return (
+            <span key={i} className={cn("relative inline-flex", size)}>
+              <Heart className={cn("absolute inset-0", size, compact ? "text-card/20" : "text-muted-foreground/30")} />
+              <Heart
+                className={cn("absolute inset-0", size, "text-destructive fill-destructive")}
+                style={{ clipPath: "inset(0 50% 0 0)" }}
+              />
+            </span>
+          );
+        }
+        // Empty heart
+        return (
+          <Heart
+            key={i}
+            className={cn(size, compact ? "text-card/20" : "text-muted-foreground/30")}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/app/src/components/challenges/GauntletMode.tsx
+++ b/app/src/components/challenges/GauntletMode.tsx
@@ -50,6 +50,7 @@ export function GauntletMode({ questions }: GauntletModeProps) {
     failedQuestion,
     failedAnswers,
     failedByTimeout,
+    lastPenalty,
     proceedToResults,
     continueAfterWrong,
   } = useGauntletMode(questions);
@@ -173,7 +174,9 @@ export function GauntletMode({ questions }: GauntletModeProps) {
                 incorrectLabel={
                   failedByTimeout
                     ? (isGameOver ? t("timeUpGameOver") : t("timeUpLifeLost"))
-                    : (isGameOver ? t("wrongGameOver") : t("wrongLifeLost"))
+                    : isGameOver ? t("wrongGameOver")
+                    : lastPenalty < 1 ? t("wrongHalfLifeLost")
+                    : t("wrongLifeLost")
                 }
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />

--- a/app/src/hooks/__tests__/useGauntletMode.test.ts
+++ b/app/src/hooks/__tests__/useGauntletMode.test.ts
@@ -296,4 +296,119 @@ describe("useGauntletMode", () => {
     expect(hook.result.current.state.phase).toBe("game_over");
     expect(hook.result.current.result).not.toBeNull();
   });
+
+  describe("multi-select partial credit", () => {
+    const makeMultiQuestion = (id: string, correctCount: number, wrongCount: number): Question => {
+      const answers = [];
+      for (let i = 0; i < correctCount; i++) {
+        answers.push({ id: `${id}-c${i}`, text: `Correct ${i}`, isCorrect: true });
+      }
+      for (let i = 0; i < wrongCount; i++) {
+        answers.push({ id: `${id}-w${i}`, text: `Wrong ${i}`, isCorrect: false });
+      }
+      return {
+        id,
+        cert: "foundations",
+        question: `Multi ${id}`,
+        answers,
+        isMultiSelect: true,
+      };
+    };
+
+    it("≥50% correct picks loses half a life (4 correct, select 2 correct + 2 wrong)", async () => {
+      const multiQ = makeMultiQuestion("m1", 4, 2);
+      const filler = makeMultiQuestion("m1f", 2, 2);
+      const hook = renderHook(() => useGauntletMode([multiQ, filler], {}));
+      await act(async () => {});
+
+      // Find the 4-correct question in shuffled order
+      let q = hook.result.current.currentQuestion!;
+      if (q.answers.filter((a) => a.isCorrect).length !== 4) {
+        // It's the filler — answer it correctly to advance
+        const correctIds = q.answers.filter((a) => a.isCorrect).map((a) => a.id);
+        for (const id of correctIds) act(() => { hook.result.current.toggleAnswer(id); });
+        act(() => { hook.result.current.confirmAnswer(); });
+        act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+        q = hook.result.current.currentQuestion!;
+      }
+
+      expect(q.isMultiSelect).toBe(true);
+      const correctAnswers = q.answers.filter((a) => a.isCorrect);
+      const wrongAnswers = q.answers.filter((a) => !a.isCorrect);
+      expect(correctAnswers).toHaveLength(4);
+
+      // Select 2 correct + 2 wrong (need correctCount=4 selections)
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[1].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[1].id); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      // 2 correct picks out of 4 needed = 50% → half life
+      expect(hook.result.current.lastPenalty).toBe(0.5);
+      expect(hook.result.current.state.phase).toBe("wrong_review");
+    });
+
+    it("<50% correct picks loses a full life (4 correct, select 1 correct + 3 wrong)", async () => {
+      const multiQ = makeMultiQuestion("m2", 4, 4);
+      const hook = renderHook(() => useGauntletMode([multiQ], {}));
+      await act(async () => {});
+
+      const q = hook.result.current.currentQuestion!;
+      const correctAnswers = q.answers.filter((a) => a.isCorrect);
+      const wrongAnswers = q.answers.filter((a) => !a.isCorrect);
+
+      // Select 1 correct + 3 wrong = 25% correct picks
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[1].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[2].id); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      // 1/4 = 25% → full life loss
+      expect(hook.result.current.state.lives).toBe(2);
+      expect(hook.result.current.lastPenalty).toBe(1);
+    });
+
+    it("single-select wrong always loses full life regardless", async () => {
+      const hook = await setup();
+      const { wrongId } = answerIds(hook);
+
+      act(() => { hook.result.current.toggleAnswer(wrongId); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      expect(hook.result.current.state.lives).toBe(2);
+      expect(hook.result.current.lastPenalty).toBe(1);
+    });
+
+    it("half-life losses accumulate correctly (3 lives → 2.5 → 2 → 1.5 → ...)", async () => {
+      // Use multiple multi-select questions where user always gets ≥50% right
+      const multiQs = Array.from({ length: 7 }, (_, i) => makeMultiQuestion(`acc${i}`, 2, 2));
+      const hook = renderHook(() => useGauntletMode(multiQs, {}));
+      await act(async () => {});
+
+      // Each wrong answer with 1/2 correct picks (50%) → half life
+      for (let i = 0; i < 6; i++) {
+        const q = hook.result.current.currentQuestion!;
+        const correct = q.answers.find((a) => a.isCorrect)!;
+        const wrong = q.answers.find((a) => !a.isCorrect)!;
+
+        // Select 1 correct + 1 wrong = 50% correct picks
+        act(() => { hook.result.current.toggleAnswer(correct.id); });
+        act(() => { hook.result.current.toggleAnswer(wrong.id); });
+        act(() => { hook.result.current.confirmAnswer(); });
+
+        const expectedLives = 3 - (i + 1) * 0.5;
+        expect(hook.result.current.state.lives).toBe(expectedLives);
+
+        if (expectedLives > 0) {
+          act(() => { hook.result.current.continueAfterWrong(); });
+        }
+      }
+
+      // After 6 half-life losses: 3 - 3 = 0 → game over
+      expect(hook.result.current.state.lives).toBe(0);
+      expect(hook.result.current.state.phase).toBe("game_over_review");
+    });
+  });
 });

--- a/app/src/hooks/useGauntletMode.ts
+++ b/app/src/hooks/useGauntletMode.ts
@@ -60,6 +60,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
   const [failedQuestion, setFailedQuestion] = useState<Question | null>(null);
   const [failedAnswers, setFailedAnswers] = useState<Set<string>>(new Set());
   const [failedByTimeout, setFailedByTimeout] = useState(false);
+  const [lastPenalty, setLastPenalty] = useState<number>(1);
 
   const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -84,12 +85,14 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
   }, []);
 
   // Handle wrong answer — routes to wrong_review (lives remaining) or game_over_review (last life)
-  const handleWrong = useCallback((question: Question, answers: Set<string>, byTimeout: boolean) => {
+  // penalty: 1 for full life loss, 0.5 for half-life (multi-select partial credit)
+  const handleWrong = useCallback((question: Question, answers: Set<string>, byTimeout: boolean, penalty: number = 1) => {
     setFailedQuestion(question);
     setFailedAnswers(new Set(answers));
     setFailedByTimeout(byTimeout);
+    setLastPenalty(penalty);
     setState((prev) => {
-      const newLives = prev.lives - 1;
+      const newLives = prev.lives - penalty;
       const isLastLife = newLives <= 0;
       return {
         ...prev,
@@ -129,6 +132,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
     setFailedQuestion(null);
     setFailedAnswers(new Set());
     setFailedByTimeout(false);
+    setLastPenalty(1);
     const shuffled = shuffle(allQuestions).map((q) => ({
       ...q,
       answers: shuffle(q.answers),
@@ -249,7 +253,18 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
         }
       }, CORRECT_ADVANCE_DELAY);
     } else {
-      handleWrong(currentQuestion, selectedAnswers, false);
+      // Multi-select partial credit: ≥50% correct picks → half-life penalty
+      let penalty = 1;
+      if (currentQuestion.isMultiSelect) {
+        const correctIds = new Set(
+          currentQuestion.answers.filter((a) => a.isCorrect).map((a) => a.id),
+        );
+        const correctPicks = [...selectedAnswers].filter((id) => correctIds.has(id)).length;
+        if (correctPicks >= correctIds.size / 2) {
+          penalty = 0.5;
+        }
+      }
+      handleWrong(currentQuestion, selectedAnswers, false, penalty);
     }
   }, [state.phase, currentQuestion, selectedAnswers, isAnswerComplete, clearAdvanceTimer, stopCountdown, pauseRequested, advanceToNext, handleWrong]);
 
@@ -304,6 +319,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
     failedQuestion,
     failedAnswers,
     failedByTimeout,
+    lastPenalty,
     proceedToResults,
     continueAfterWrong,
   };


### PR DESCRIPTION
Multi-select questions with ≥50% correct picks now lose only half a life instead of a full life. Single-select scoring unchanged.

- useGauntletMode: parameterized penalty (0.5 or 1) based on accuracy
- LivesDisplay: half-heart rendering via CSS clipPath
- GauntletMode: 'partially correct' feedback message
- 4 new test cases for partial credit scenarios

Related issue: #579

