### PR TITLE
feat: Time Trial max time cap (120s)

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -210,8 +210,9 @@
   },
   "TimeTrial": {
     "title": "Time Trial",
-    "correctFeedback": "Correct! +15 seconds!",
-    "incorrectFeedback": "Wrong! −5 seconds!",
+    "correctFeedback": "Correct! +{seconds} seconds!",
+    "maxTimeFeedback": "Correct! Time is at maximum!",
+    "incorrectFeedback": "Wrong! −{seconds} seconds!",
     "questionsAnswered": "questions answered correctly",
     "wrong": "Wrong",
     "resultLegendary": "Time Lord!",

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -211,7 +211,7 @@
   "TimeTrial": {
     "title": "Time Trial",
     "correctFeedback": "Correct! +{seconds} seconds!",
-    "maxTimeFeedback": "Correct! Time is at maximum!",
+    "cappedFeedback": "Correct! +{seconds} seconds (max 2:00)!",
     "incorrectFeedback": "Wrong! −{seconds} seconds!",
     "questionsAnswered": "questions answered correctly",
     "wrong": "Wrong",

--- a/app/src/components/challenges/TimeTrialMode.tsx
+++ b/app/src/components/challenges/TimeTrialMode.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from "react";
 import type { Question } from "@/types/quiz";
 import { cn } from "@/lib/utils";
-import { useTimeTrialMode, INITIAL_TIME, CORRECT_BONUS, WRONG_PENALTY } from "@/hooks/useTimeTrialMode";
+import { useTimeTrialMode, MAX_TIME, CORRECT_BONUS, WRONG_PENALTY } from "@/hooks/useTimeTrialMode";
 import { useTranslations } from "next-intl";
 import { renderCodeSpans } from "@/lib/render-code-spans";
 import { QuestionCard } from "@/components/quiz/QuestionCard";
@@ -198,8 +198,8 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
 
               <FeedbackAlert
                 isCorrect={false}
-                correctLabel={t("correctFeedback")}
-                incorrectLabel={t("incorrectFeedback")}
+                correctLabel={t("correctFeedback", { seconds: CORRECT_BONUS })}
+                incorrectLabel={t("incorrectFeedback", { seconds: Math.abs(lastDelta ?? WRONG_PENALTY) })}
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />
 
@@ -324,8 +324,8 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
             {isFeedback && state.lastAnswerCorrect !== null && (
               <FeedbackAlert
                 isCorrect={state.lastAnswerCorrect}
-                correctLabel={t("correctFeedback")}
-                incorrectLabel={t("incorrectFeedback")}
+                correctLabel={lastDelta === 0 ? t("maxTimeFeedback") : t("correctFeedback", { seconds: lastDelta ?? CORRECT_BONUS })}
+                incorrectLabel={t("incorrectFeedback", { seconds: Math.abs(lastDelta ?? WRONG_PENALTY) })}
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />
             )}
@@ -366,6 +366,7 @@ function TimeDeltaPopup({ delta, triggerKey }: { delta: number | null; triggerKe
   if (!visible || displayDelta === null) return null;
 
   const isPositive = displayDelta > 0;
+  const isZero = displayDelta === 0;
 
   return (
     <span
@@ -373,10 +374,10 @@ function TimeDeltaPopup({ delta, triggerKey }: { delta: number | null; triggerKe
       className={cn(
         "absolute -top-6 left-1/2 -translate-x-1/2 font-display text-[14px] font-extrabold tabular-nums pointer-events-none whitespace-nowrap",
         "motion-safe:animate-out motion-safe:fade-out motion-safe:slide-out-to-top-4 motion-safe:duration-1000 motion-safe:fill-forwards",
-        isPositive ? "text-emerald-500" : "text-destructive",
+        isZero ? "text-amber-500" : isPositive ? "text-emerald-500" : "text-destructive",
       )}
     >
-      {isPositive ? `+${displayDelta}s` : `${displayDelta}s`}
+      {isZero ? "MAX" : isPositive ? `+${displayDelta}s` : `${displayDelta}s`}
     </span>
   );
 }
@@ -404,7 +405,8 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
     );
   }
 
-  const fraction = Math.min(timeRemaining / INITIAL_TIME, 1);
+  const fraction = Math.min(timeRemaining / MAX_TIME, 1);
+  const isAtMax = timeRemaining >= MAX_TIME;
 
   return (
     <div className="flex items-center gap-2.5 w-full">
@@ -413,14 +415,14 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
         <div
           className={cn(
             "h-full w-full rounded-full transition-transform duration-1000 ease-linear origin-left",
-            isCritical ? "bg-destructive" : isLow ? "bg-warning" : "bg-primary",
+            isAtMax ? "bg-amber-500" : isCritical ? "bg-destructive" : isLow ? "bg-warning" : "bg-primary",
           )}
           style={{ transform: `scaleX(${Math.max(0, fraction)})` }}
         />
       </div>
       <span className={cn(
         "font-display text-[14px] font-bold tabular-nums min-w-[40px] text-right",
-        isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-foreground",
+        isAtMax ? "text-amber-500" : isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-foreground",
       )}>
         {display}
       </span>

--- a/app/src/components/challenges/TimeTrialMode.tsx
+++ b/app/src/components/challenges/TimeTrialMode.tsx
@@ -324,7 +324,11 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
             {isFeedback && state.lastAnswerCorrect !== null && (
               <FeedbackAlert
                 isCorrect={state.lastAnswerCorrect}
-                correctLabel={lastDelta === 0 ? t("maxTimeFeedback") : t("correctFeedback", { seconds: lastDelta ?? CORRECT_BONUS })}
+                correctLabel={
+                  lastDelta !== null && lastDelta < CORRECT_BONUS && timeRemaining >= MAX_TIME
+                    ? t("cappedFeedback", { seconds: lastDelta })
+                    : t("correctFeedback", { seconds: lastDelta ?? CORRECT_BONUS })
+                }
                 incorrectLabel={t("incorrectFeedback", { seconds: Math.abs(lastDelta ?? WRONG_PENALTY) })}
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   useTimeTrialMode,
   INITIAL_TIME,
+  MAX_TIME,
   CORRECT_BONUS,
   WRONG_PENALTY,
 } from "@/hooks/useTimeTrialMode";
@@ -268,5 +269,110 @@ describe("useTimeTrialMode", () => {
     // Resume
     act(() => { result.current.togglePause(); });
     expect(result.current.state.phase).toBe("playing");
+  });
+
+  it("correct answer caps time at MAX_TIME", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Time starts at INITIAL_TIME (90). Answer multiple correct to approach cap.
+    // First correct: 90 + 15 = 105
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS); // 105
+    act(() => { vi.advanceTimersByTime(1200 + 50); }); // advance past feedback
+
+    // Second correct: 105 + 15 = 120 (exactly MAX_TIME)
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME); // 120
+    expect(result.current.lastDelta).toBe(CORRECT_BONUS); // full bonus applied
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+
+    // Third correct: 120 + 15 would be 135, but capped at 120
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME); // stays at 120
+    expect(result.current.lastDelta).toBe(0); // no time actually gained
+  });
+
+  it("totalGained tracks actual capped amounts", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // At 90: correct → 105, gained = 15
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(15);
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+
+    // At 105: correct → 120 (capped), gained = 15
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(30);
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+
+    // At 120: correct → 120 (capped), gained = 0
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(30); // unchanged
+    expect(result.current.lastDelta).toBe(0);
+  });
+
+  it("wrong answer near zero tracks actual loss", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Drain time to 3 seconds
+    const ticksNeeded = INITIAL_TIME - 3;
+    act(() => { vi.advanceTimersByTime(ticksNeeded * 1000); });
+    expect(result.current.timeRemaining).toBe(3);
+
+    // Wrong answer: penalty is 5 but only 3 available
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.timeRemaining).toBe(0);
+    expect(result.current.lastDelta).toBe(-3); // actual loss, not -5
+    expect(result.current.totalLost).toBe(3); // actual loss
+  });
+
+  it("correct answer near cap gives partial bonus", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Get to 113: answer one correct (90→105), then drain 105 down by waiting
+    // but timer stops during feedback... Let's just use two corrects + drain.
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    // At 105, in feedback (timer stopped)
+    act(() => { vi.advanceTimersByTime(1200 + 50); }); // advance to next Q
+
+    // Now playing at 105. Drain to 113 by... wait, 105 already. We need to get to near 120.
+    // Answer another correct: 105→120
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME);
+    act(() => { vi.advanceTimersByTime(1200 + 50); });
+
+    // Now at 120, drain to 113 (7 seconds tick during playing)
+    act(() => { vi.advanceTimersByTime(7000); });
+    expect(result.current.timeRemaining).toBe(113);
+
+    // Answer correct: 113 + 15 = 128, capped at 120. Actual gain = 7.
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME);
+    expect(result.current.lastDelta).toBe(7); // partial bonus
   });
 });

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -198,13 +198,13 @@ describe("useTimeTrialMode", () => {
     let correctId = getCorrectId(result.current);
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
-    act(() => { vi.advanceTimersByTime(1200 + 50); }); // FEEDBACK_ADVANCE_DELAY
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // FEEDBACK_ADVANCE_DELAY
 
     // Answer question 2 correctly
     correctId = getCorrectId(result.current);
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     expect(result.current.state.phase).toBe("game_over");
     expect(result.current.state.correct).toBe(2);
@@ -225,7 +225,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.state.phase).toBe("feedback");
 
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
     expect(result.current.state.phase).toBe("paused");
 
     // Resume
@@ -281,7 +281,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS); // 105
-    act(() => { vi.advanceTimersByTime(1200 + 50); }); // advance past feedback
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // advance past feedback
 
     // Second correct: 105 + 15 = 120 (exactly MAX_TIME)
     correctId = getCorrectId(result.current);
@@ -289,7 +289,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.timeRemaining).toBe(MAX_TIME); // 120
     expect(result.current.lastDelta).toBe(CORRECT_BONUS); // full bonus applied
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     // Third correct: 120 + 15 would be 135, but capped at 120
     correctId = getCorrectId(result.current);
@@ -308,14 +308,14 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.totalGained).toBe(15);
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     // At 105: correct → 120 (capped), gained = 15
     correctId = getCorrectId(result.current);
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.totalGained).toBe(30);
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     // At 120: correct → 120 (capped), gained = 0
     correctId = getCorrectId(result.current);
@@ -354,7 +354,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
     // At 105, in feedback (timer stopped)
-    act(() => { vi.advanceTimersByTime(1200 + 50); }); // advance to next Q
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // advance to next Q
 
     // Now playing at 105. Drain to 113 by... wait, 105 already. We need to get to near 120.
     // Answer another correct: 105→120
@@ -362,7 +362,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.timeRemaining).toBe(MAX_TIME);
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     // Now at 120, drain to 113 (7 seconds tick during playing)
     act(() => { vi.advanceTimersByTime(7000); });

--- a/app/src/hooks/useTimeTrialMode.ts
+++ b/app/src/hooks/useTimeTrialMode.ts
@@ -28,7 +28,7 @@ interface TimeTrialState {
   lastAnswerCorrect: boolean | null;
 }
 
-const FEEDBACK_ADVANCE_DELAY = 1200;
+const FEEDBACK_ADVANCE_DELAY = 1800;
 
 /** Starting time in seconds. */
 export const INITIAL_TIME = 90;

--- a/app/src/hooks/useTimeTrialMode.ts
+++ b/app/src/hooks/useTimeTrialMode.ts
@@ -32,6 +32,8 @@ const FEEDBACK_ADVANCE_DELAY = 1200;
 
 /** Starting time in seconds. */
 export const INITIAL_TIME = 90;
+/** Maximum time allowed (cap). */
+export const MAX_TIME = 120;
 /** Seconds added for a correct answer. */
 export const CORRECT_BONUS = 15;
 /** Seconds subtracted for a wrong answer. */
@@ -106,15 +108,18 @@ export function useTimeTrialMode(allQuestions: Question[]) {
     setSelectedAnswers(new Set());
   }, []);
 
-  // Adjust timer by delta (positive = add, negative = subtract)
-  const adjustTime = useCallback((delta: number) => {
-    const newTime = Math.max(0, timeRemainingRef.current + delta);
+  // Adjust timer by delta (positive = add, negative = subtract), capped at [0, MAX_TIME].
+  // Returns the actual delta applied after clamping.
+  const adjustTime = useCallback((delta: number): number => {
+    const oldTime = timeRemainingRef.current;
+    const newTime = Math.min(MAX_TIME, Math.max(0, oldTime + delta));
     timeRemainingRef.current = newTime;
     setTimeRemaining(newTime);
     if (newTime <= 0) {
       stopCountdown();
       setState((prev) => ({ ...prev, phase: "game_over" }));
     }
+    return newTime - oldTime;
   }, [stopCountdown]);
 
   // Initialize / restart
@@ -206,6 +211,8 @@ export function useTimeTrialMode(allQuestions: Question[]) {
 
   const confirmAnswer = useCallback(() => {
     if (state.phase !== "playing" || !currentQuestion || !isAnswerComplete()) return;
+    // Guard: if timer already expired between render and click, bail out
+    if (timeRemainingRef.current <= 0) return;
 
     // Pause timer during feedback
     stopCountdown();
@@ -218,9 +225,9 @@ export function useTimeTrialMode(allQuestions: Question[]) {
       [...selectedAnswers].every((id) => correctIds.has(id));
 
     if (isCorrect) {
-      adjustTime(CORRECT_BONUS);
-      setTotalGained((prev) => prev + CORRECT_BONUS);
-      setLastDelta(CORRECT_BONUS);
+      const actual = adjustTime(CORRECT_BONUS);
+      setTotalGained((prev) => prev + actual);
+      setLastDelta(actual);
       setDeltaKey((prev) => prev + 1);
       setState((prev) => ({
         ...prev,
@@ -239,9 +246,9 @@ export function useTimeTrialMode(allQuestions: Question[]) {
       }, FEEDBACK_ADVANCE_DELAY);
     } else {
       // Wrong answer — subtract penalty, show review
-      adjustTime(-WRONG_PENALTY);
-      setTotalLost((prev) => prev + WRONG_PENALTY);
-      setLastDelta(-WRONG_PENALTY);
+      const actual = adjustTime(-WRONG_PENALTY);
+      setTotalLost((prev) => prev + Math.abs(actual));
+      setLastDelta(actual);
       setDeltaKey((prev) => prev + 1);
       setFailedQuestion(currentQuestion);
       setFailedAnswers(new Set(selectedAnswers));


### PR DESCRIPTION
## Summary

Add a configurable max time cap (120 seconds) for Time Trial mode, preventing unlimited time accumulation from correct answers.

Closes #613

## Changes

### Hook (`useTimeTrialMode.ts`)
- `MAX_TIME = 120` exported constant
- `adjustTime()` clamps to `[0, MAX_TIME]`, returns actual delta applied
- `confirmAnswer()` tracks real capped deltas for `totalGained`/`totalLost`/`lastDelta`
- Guard against stale submit when timer already at 0

### UI (`TimeTrialMode.tsx`)
- Progress bar denominator → `MAX_TIME` (starts 75% at 90s, fills to 100%)
- Bar + timer text turn **amber** at max
- Delta popup shows **"MAX"** (amber) when delta is 0

### i18n (`en.json`)
- `incorrectFeedback`: `"Wrong! −

### Tests
- 5 new tests (17 total): cap enforcement, partial bonus, actual delta tracking, partial wrong penalty near zero
- All 74 suite tests pass
