### PR TITLE
feat: half-life penalties for multi-select in gauntlet + max time cap in time trial + more time gained for multi select correct answers

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -210,8 +210,9 @@
   },
   "TimeTrial": {
     "title": "Time Trial",
-    "correctFeedback": "Correct! +15 seconds!",
-    "incorrectFeedback": "Wrong! −5 seconds!",
+    "correctFeedback": "Correct! +{seconds} seconds!",
+    "cappedFeedback": "Correct! +{seconds} seconds (max 2:00)!",
+    "incorrectFeedback": "Wrong! −{seconds} seconds!",
     "questionsAnswered": "questions answered correctly",
     "wrong": "Wrong",
     "resultLegendary": "Time Lord!",

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -194,6 +194,7 @@
   "Gauntlet": {
     "correctFeedback": "Correct! Keep going!",
     "wrongLifeLost": "Wrong answer — you lost a life!",
+    "wrongHalfLifeLost": "Almost there — lost only half a life!",
     "wrongGameOver": "Wrong answer — game over!",
     "timeUpLifeLost": "Time's up — you lost a life!",
     "timeUpGameOver": "Time's up — game over!",

--- a/app/src/components/challenges/ChallengeSidebar.tsx
+++ b/app/src/components/challenges/ChallengeSidebar.tsx
@@ -22,17 +22,37 @@ export function LivesDisplay({ lives, initialLives, compact }: { lives: number; 
   const size = compact ? "size-3.5" : "size-5";
   return (
     <div className="flex items-center gap-0.5">
-      {Array.from({ length: initialLives }, (_, i) => (
-        <Heart
-          key={i}
-          className={cn(
-            size,
-            i < lives
-              ? "text-destructive fill-destructive"
-              : compact ? "text-card/20" : "text-muted-foreground/30",
-          )}
-        />
-      ))}
+      {Array.from({ length: initialLives }, (_, i) => {
+        const remaining = lives - i;
+        if (remaining >= 1) {
+          // Full heart
+          return (
+            <Heart
+              key={i}
+              className={cn(size, "text-destructive fill-destructive")}
+            />
+          );
+        }
+        if (remaining > 0) {
+          // Half heart — filled left half over empty heart
+          return (
+            <span key={i} className={cn("relative inline-flex", size)}>
+              <Heart className={cn("absolute inset-0", size, compact ? "text-card/20" : "text-muted-foreground/30")} />
+              <Heart
+                className={cn("absolute inset-0", size, "text-destructive fill-destructive")}
+                style={{ clipPath: "inset(0 50% 0 0)" }}
+              />
+            </span>
+          );
+        }
+        // Empty heart
+        return (
+          <Heart
+            key={i}
+            className={cn(size, compact ? "text-card/20" : "text-muted-foreground/30")}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/app/src/components/challenges/GauntletMode.tsx
+++ b/app/src/components/challenges/GauntletMode.tsx
@@ -50,6 +50,7 @@ export function GauntletMode({ questions }: GauntletModeProps) {
     failedQuestion,
     failedAnswers,
     failedByTimeout,
+    lastPenalty,
     proceedToResults,
     continueAfterWrong,
   } = useGauntletMode(questions);
@@ -173,7 +174,9 @@ export function GauntletMode({ questions }: GauntletModeProps) {
                 incorrectLabel={
                   failedByTimeout
                     ? (isGameOver ? t("timeUpGameOver") : t("timeUpLifeLost"))
-                    : (isGameOver ? t("wrongGameOver") : t("wrongLifeLost"))
+                    : isGameOver ? t("wrongGameOver")
+                    : lastPenalty < 1 ? t("wrongHalfLifeLost")
+                    : t("wrongLifeLost")
                 }
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />

--- a/app/src/components/challenges/TimeTrialMode.tsx
+++ b/app/src/components/challenges/TimeTrialMode.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from "react";
 import type { Question } from "@/types/quiz";
 import { cn } from "@/lib/utils";
-import { useTimeTrialMode, INITIAL_TIME, CORRECT_BONUS, WRONG_PENALTY } from "@/hooks/useTimeTrialMode";
+import { useTimeTrialMode, MAX_TIME, CORRECT_BONUS, WRONG_PENALTY } from "@/hooks/useTimeTrialMode";
 import { useTranslations } from "next-intl";
 import { renderCodeSpans } from "@/lib/render-code-spans";
 import { QuestionCard } from "@/components/quiz/QuestionCard";
@@ -198,8 +198,8 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
 
               <FeedbackAlert
                 isCorrect={false}
-                correctLabel={t("correctFeedback")}
-                incorrectLabel={t("incorrectFeedback")}
+                correctLabel={t("correctFeedback", { seconds: CORRECT_BONUS })}
+                incorrectLabel={t("incorrectFeedback", { seconds: Math.abs(lastDelta ?? WRONG_PENALTY) })}
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />
 
@@ -324,8 +324,12 @@ export function TimeTrialMode({ questions }: TimeTrialModeProps) {
             {isFeedback && state.lastAnswerCorrect !== null && (
               <FeedbackAlert
                 isCorrect={state.lastAnswerCorrect}
-                correctLabel={t("correctFeedback")}
-                incorrectLabel={t("incorrectFeedback")}
+                correctLabel={
+                  lastDelta !== null && lastDelta < CORRECT_BONUS && timeRemaining >= MAX_TIME
+                    ? t("cappedFeedback", { seconds: lastDelta })
+                    : t("correctFeedback", { seconds: lastDelta ?? CORRECT_BONUS })
+                }
+                incorrectLabel={t("incorrectFeedback", { seconds: Math.abs(lastDelta ?? WRONG_PENALTY) })}
                 className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200"
               />
             )}
@@ -366,6 +370,7 @@ function TimeDeltaPopup({ delta, triggerKey }: { delta: number | null; triggerKe
   if (!visible || displayDelta === null) return null;
 
   const isPositive = displayDelta > 0;
+  const isZero = displayDelta === 0;
 
   return (
     <span
@@ -373,10 +378,10 @@ function TimeDeltaPopup({ delta, triggerKey }: { delta: number | null; triggerKe
       className={cn(
         "absolute -top-6 left-1/2 -translate-x-1/2 font-display text-[14px] font-extrabold tabular-nums pointer-events-none whitespace-nowrap",
         "motion-safe:animate-out motion-safe:fade-out motion-safe:slide-out-to-top-4 motion-safe:duration-1000 motion-safe:fill-forwards",
-        isPositive ? "text-emerald-500" : "text-destructive",
+        isZero ? "text-amber-500" : isPositive ? "text-emerald-500" : "text-destructive",
       )}
     >
-      {isPositive ? `+${displayDelta}s` : `${displayDelta}s`}
+      {isZero ? "MAX" : isPositive ? `+${displayDelta}s` : `${displayDelta}s`}
     </span>
   );
 }
@@ -404,7 +409,8 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
     );
   }
 
-  const fraction = Math.min(timeRemaining / INITIAL_TIME, 1);
+  const fraction = Math.min(timeRemaining / MAX_TIME, 1);
+  const isAtMax = timeRemaining >= MAX_TIME;
 
   return (
     <div className="flex items-center gap-2.5 w-full">
@@ -413,14 +419,14 @@ function GlobalTimerDisplay({ timeRemaining, compact }: { timeRemaining: number;
         <div
           className={cn(
             "h-full w-full rounded-full transition-transform duration-1000 ease-linear origin-left",
-            isCritical ? "bg-destructive" : isLow ? "bg-warning" : "bg-primary",
+            isAtMax ? "bg-amber-500" : isCritical ? "bg-destructive" : isLow ? "bg-warning" : "bg-primary",
           )}
           style={{ transform: `scaleX(${Math.max(0, fraction)})` }}
         />
       </div>
       <span className={cn(
         "font-display text-[14px] font-bold tabular-nums min-w-[40px] text-right",
-        isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-foreground",
+        isAtMax ? "text-amber-500" : isCritical ? "text-destructive motion-safe:animate-pulse" : isLow ? "text-warning" : "text-foreground",
       )}>
         {display}
       </span>

--- a/app/src/hooks/__tests__/useGauntletMode.test.ts
+++ b/app/src/hooks/__tests__/useGauntletMode.test.ts
@@ -296,4 +296,119 @@ describe("useGauntletMode", () => {
     expect(hook.result.current.state.phase).toBe("game_over");
     expect(hook.result.current.result).not.toBeNull();
   });
+
+  describe("multi-select partial credit", () => {
+    const makeMultiQuestion = (id: string, correctCount: number, wrongCount: number): Question => {
+      const answers = [];
+      for (let i = 0; i < correctCount; i++) {
+        answers.push({ id: `${id}-c${i}`, text: `Correct ${i}`, isCorrect: true });
+      }
+      for (let i = 0; i < wrongCount; i++) {
+        answers.push({ id: `${id}-w${i}`, text: `Wrong ${i}`, isCorrect: false });
+      }
+      return {
+        id,
+        cert: "foundations",
+        question: `Multi ${id}`,
+        answers,
+        isMultiSelect: true,
+      };
+    };
+
+    it("≥50% correct picks loses half a life (4 correct, select 2 correct + 2 wrong)", async () => {
+      const multiQ = makeMultiQuestion("m1", 4, 2);
+      const filler = makeMultiQuestion("m1f", 2, 2);
+      const hook = renderHook(() => useGauntletMode([multiQ, filler], {}));
+      await act(async () => {});
+
+      // Find the 4-correct question in shuffled order
+      let q = hook.result.current.currentQuestion!;
+      if (q.answers.filter((a) => a.isCorrect).length !== 4) {
+        // It's the filler — answer it correctly to advance
+        const correctIds = q.answers.filter((a) => a.isCorrect).map((a) => a.id);
+        for (const id of correctIds) act(() => { hook.result.current.toggleAnswer(id); });
+        act(() => { hook.result.current.confirmAnswer(); });
+        act(() => { vi.advanceTimersByTime(CORRECT_ADVANCE_DELAY + 50); });
+        q = hook.result.current.currentQuestion!;
+      }
+
+      expect(q.isMultiSelect).toBe(true);
+      const correctAnswers = q.answers.filter((a) => a.isCorrect);
+      const wrongAnswers = q.answers.filter((a) => !a.isCorrect);
+      expect(correctAnswers).toHaveLength(4);
+
+      // Select 2 correct + 2 wrong (need correctCount=4 selections)
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[1].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[1].id); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      // 2 correct picks out of 4 needed = 50% → half life
+      expect(hook.result.current.lastPenalty).toBe(0.5);
+      expect(hook.result.current.state.phase).toBe("wrong_review");
+    });
+
+    it("<50% correct picks loses a full life (4 correct, select 1 correct + 3 wrong)", async () => {
+      const multiQ = makeMultiQuestion("m2", 4, 4);
+      const hook = renderHook(() => useGauntletMode([multiQ], {}));
+      await act(async () => {});
+
+      const q = hook.result.current.currentQuestion!;
+      const correctAnswers = q.answers.filter((a) => a.isCorrect);
+      const wrongAnswers = q.answers.filter((a) => !a.isCorrect);
+
+      // Select 1 correct + 3 wrong = 25% correct picks
+      act(() => { hook.result.current.toggleAnswer(correctAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[0].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[1].id); });
+      act(() => { hook.result.current.toggleAnswer(wrongAnswers[2].id); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      // 1/4 = 25% → full life loss
+      expect(hook.result.current.state.lives).toBe(2);
+      expect(hook.result.current.lastPenalty).toBe(1);
+    });
+
+    it("single-select wrong always loses full life regardless", async () => {
+      const hook = await setup();
+      const { wrongId } = answerIds(hook);
+
+      act(() => { hook.result.current.toggleAnswer(wrongId); });
+      act(() => { hook.result.current.confirmAnswer(); });
+
+      expect(hook.result.current.state.lives).toBe(2);
+      expect(hook.result.current.lastPenalty).toBe(1);
+    });
+
+    it("half-life losses accumulate correctly (3 lives → 2.5 → 2 → 1.5 → ...)", async () => {
+      // Use multiple multi-select questions where user always gets ≥50% right
+      const multiQs = Array.from({ length: 7 }, (_, i) => makeMultiQuestion(`acc${i}`, 2, 2));
+      const hook = renderHook(() => useGauntletMode(multiQs, {}));
+      await act(async () => {});
+
+      // Each wrong answer with 1/2 correct picks (50%) → half life
+      for (let i = 0; i < 6; i++) {
+        const q = hook.result.current.currentQuestion!;
+        const correct = q.answers.find((a) => a.isCorrect)!;
+        const wrong = q.answers.find((a) => !a.isCorrect)!;
+
+        // Select 1 correct + 1 wrong = 50% correct picks
+        act(() => { hook.result.current.toggleAnswer(correct.id); });
+        act(() => { hook.result.current.toggleAnswer(wrong.id); });
+        act(() => { hook.result.current.confirmAnswer(); });
+
+        const expectedLives = 3 - (i + 1) * 0.5;
+        expect(hook.result.current.state.lives).toBe(expectedLives);
+
+        if (expectedLives > 0) {
+          act(() => { hook.result.current.continueAfterWrong(); });
+        }
+      }
+
+      // After 6 half-life losses: 3 - 3 = 0 → game over
+      expect(hook.result.current.state.lives).toBe(0);
+      expect(hook.result.current.state.phase).toBe("game_over_review");
+    });
+  });
 });

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   useTimeTrialMode,
   INITIAL_TIME,
+  MAX_TIME,
   CORRECT_BONUS,
   WRONG_PENALTY,
 } from "@/hooks/useTimeTrialMode";
@@ -197,13 +198,13 @@ describe("useTimeTrialMode", () => {
     let correctId = getCorrectId(result.current);
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
-    act(() => { vi.advanceTimersByTime(1200 + 50); }); // FEEDBACK_ADVANCE_DELAY
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // FEEDBACK_ADVANCE_DELAY
 
     // Answer question 2 correctly
     correctId = getCorrectId(result.current);
     act(() => { result.current.toggleAnswer(correctId); });
     act(() => { result.current.confirmAnswer(); });
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
 
     expect(result.current.state.phase).toBe("game_over");
     expect(result.current.state.correct).toBe(2);
@@ -224,7 +225,7 @@ describe("useTimeTrialMode", () => {
     act(() => { result.current.confirmAnswer(); });
     expect(result.current.state.phase).toBe("feedback");
 
-    act(() => { vi.advanceTimersByTime(1200 + 50); });
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
     expect(result.current.state.phase).toBe("paused");
 
     // Resume
@@ -268,5 +269,110 @@ describe("useTimeTrialMode", () => {
     // Resume
     act(() => { result.current.togglePause(); });
     expect(result.current.state.phase).toBe("playing");
+  });
+
+  it("correct answer caps time at MAX_TIME", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Time starts at INITIAL_TIME (90). Answer multiple correct to approach cap.
+    // First correct: 90 + 15 = 105
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS); // 105
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // advance past feedback
+
+    // Second correct: 105 + 15 = 120 (exactly MAX_TIME)
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME); // 120
+    expect(result.current.lastDelta).toBe(CORRECT_BONUS); // full bonus applied
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
+
+    // Third correct: 120 + 15 would be 135, but capped at 120
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME); // stays at 120
+    expect(result.current.lastDelta).toBe(0); // no time actually gained
+  });
+
+  it("totalGained tracks actual capped amounts", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // At 90: correct → 105, gained = 15
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(15);
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
+
+    // At 105: correct → 120 (capped), gained = 15
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(30);
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
+
+    // At 120: correct → 120 (capped), gained = 0
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.totalGained).toBe(30); // unchanged
+    expect(result.current.lastDelta).toBe(0);
+  });
+
+  it("wrong answer near zero tracks actual loss", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Drain time to 3 seconds
+    const ticksNeeded = INITIAL_TIME - 3;
+    act(() => { vi.advanceTimersByTime(ticksNeeded * 1000); });
+    expect(result.current.timeRemaining).toBe(3);
+
+    // Wrong answer: penalty is 5 but only 3 available
+    const wrongId = getWrongId(result.current);
+    act(() => { result.current.toggleAnswer(wrongId); });
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.timeRemaining).toBe(0);
+    expect(result.current.lastDelta).toBe(-3); // actual loss, not -5
+    expect(result.current.totalLost).toBe(3); // actual loss
+  });
+
+  it("correct answer near cap gives partial bonus", () => {
+    const { result } = renderHook(() => useTimeTrialMode(questions));
+    act(() => {});
+
+    // Get to 113: answer one correct (90→105), then drain 105 down by waiting
+    // but timer stops during feedback... Let's just use two corrects + drain.
+    let correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    // At 105, in feedback (timer stopped)
+    act(() => { vi.advanceTimersByTime(1800 + 50); }); // advance to next Q
+
+    // Now playing at 105. Drain to 113 by... wait, 105 already. We need to get to near 120.
+    // Answer another correct: 105→120
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME);
+    act(() => { vi.advanceTimersByTime(1800 + 50); });
+
+    // Now at 120, drain to 113 (7 seconds tick during playing)
+    act(() => { vi.advanceTimersByTime(7000); });
+    expect(result.current.timeRemaining).toBe(113);
+
+    // Answer correct: 113 + 15 = 128, capped at 120. Actual gain = 7.
+    correctId = getCorrectId(result.current);
+    act(() => { result.current.toggleAnswer(correctId); });
+    act(() => { result.current.confirmAnswer(); });
+    expect(result.current.timeRemaining).toBe(MAX_TIME);
+    expect(result.current.lastDelta).toBe(7); // partial bonus
   });
 });

--- a/app/src/hooks/__tests__/useTimeTrialMode.test.ts
+++ b/app/src/hooks/__tests__/useTimeTrialMode.test.ts
@@ -6,6 +6,7 @@ import {
   INITIAL_TIME,
   MAX_TIME,
   CORRECT_BONUS,
+  CORRECT_BONUS_MULTI,
   WRONG_PENALTY,
 } from "@/hooks/useTimeTrialMode";
 import type { Question } from "@/types/quiz";
@@ -19,6 +20,18 @@ const makeQuestion = (id: string, correctId: string, wrongId: string): Question 
     { id: wrongId, text: "Wrong", isCorrect: false },
   ],
   isMultiSelect: false,
+});
+
+const makeMultiSelectQuestion = (id: string): Question => ({
+  id,
+  cert: "foundations",
+  question: `Multi ${id}`,
+  answers: [
+    { id: `${id}-c1`, text: "Correct 1", isCorrect: true },
+    { id: `${id}-c2`, text: "Correct 2", isCorrect: true },
+    { id: `${id}-w1`, text: "Wrong 1", isCorrect: false },
+  ],
+  isMultiSelect: true,
 });
 
 const questions = [
@@ -71,6 +84,30 @@ describe("useTimeTrialMode", () => {
     expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS);
     expect(result.current.totalGained).toBe(CORRECT_BONUS);
     expect(result.current.lastDelta).toBe(CORRECT_BONUS);
+  });
+
+  it("correct multi-select answer adds higher time bonus", () => {
+    const multiQuestions = [
+      makeMultiSelectQuestion("mq1"),
+      makeMultiSelectQuestion("mq2"),
+      makeMultiSelectQuestion("mq3"),
+    ];
+    const { result } = renderHook(() => useTimeTrialMode(multiQuestions));
+    act(() => {});
+
+    // All questions are multi-select, so whichever comes first works
+    const q = result.current.currentQuestion!;
+    const correctIds = q.answers.filter((a) => a.isCorrect).map((a) => a.id);
+    for (const id of correctIds) {
+      act(() => { result.current.toggleAnswer(id); });
+    }
+    act(() => { result.current.confirmAnswer(); });
+
+    expect(result.current.state.phase).toBe("feedback");
+    expect(result.current.state.correct).toBe(1);
+    expect(result.current.timeRemaining).toBe(INITIAL_TIME + CORRECT_BONUS_MULTI);
+    expect(result.current.totalGained).toBe(CORRECT_BONUS_MULTI);
+    expect(result.current.lastDelta).toBe(CORRECT_BONUS_MULTI);
   });
 
   it("wrong answer subtracts time penalty", () => {

--- a/app/src/hooks/useGauntletMode.ts
+++ b/app/src/hooks/useGauntletMode.ts
@@ -256,9 +256,6 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
       // Multi-select partial credit: ≥50% correct picks → half-life penalty
       let penalty = 1;
       if (currentQuestion.isMultiSelect) {
-        const correctIds = new Set(
-          currentQuestion.answers.filter((a) => a.isCorrect).map((a) => a.id),
-        );
         const correctPicks = [...selectedAnswers].filter((id) => correctIds.has(id)).length;
         if (correctPicks >= correctIds.size / 2) {
           penalty = 0.5;

--- a/app/src/hooks/useGauntletMode.ts
+++ b/app/src/hooks/useGauntletMode.ts
@@ -60,6 +60,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
   const [failedQuestion, setFailedQuestion] = useState<Question | null>(null);
   const [failedAnswers, setFailedAnswers] = useState<Set<string>>(new Set());
   const [failedByTimeout, setFailedByTimeout] = useState(false);
+  const [lastPenalty, setLastPenalty] = useState<number>(1);
 
   const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -84,12 +85,14 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
   }, []);
 
   // Handle wrong answer — routes to wrong_review (lives remaining) or game_over_review (last life)
-  const handleWrong = useCallback((question: Question, answers: Set<string>, byTimeout: boolean) => {
+  // penalty: 1 for full life loss, 0.5 for half-life (multi-select partial credit)
+  const handleWrong = useCallback((question: Question, answers: Set<string>, byTimeout: boolean, penalty: number = 1) => {
     setFailedQuestion(question);
     setFailedAnswers(new Set(answers));
     setFailedByTimeout(byTimeout);
+    setLastPenalty(penalty);
     setState((prev) => {
-      const newLives = prev.lives - 1;
+      const newLives = prev.lives - penalty;
       const isLastLife = newLives <= 0;
       return {
         ...prev,
@@ -129,6 +132,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
     setFailedQuestion(null);
     setFailedAnswers(new Set());
     setFailedByTimeout(false);
+    setLastPenalty(1);
     const shuffled = shuffle(allQuestions).map((q) => ({
       ...q,
       answers: shuffle(q.answers),
@@ -249,7 +253,18 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
         }
       }, CORRECT_ADVANCE_DELAY);
     } else {
-      handleWrong(currentQuestion, selectedAnswers, false);
+      // Multi-select partial credit: ≥50% correct picks → half-life penalty
+      let penalty = 1;
+      if (currentQuestion.isMultiSelect) {
+        const correctIds = new Set(
+          currentQuestion.answers.filter((a) => a.isCorrect).map((a) => a.id),
+        );
+        const correctPicks = [...selectedAnswers].filter((id) => correctIds.has(id)).length;
+        if (correctPicks >= correctIds.size / 2) {
+          penalty = 0.5;
+        }
+      }
+      handleWrong(currentQuestion, selectedAnswers, false, penalty);
     }
   }, [state.phase, currentQuestion, selectedAnswers, isAnswerComplete, clearAdvanceTimer, stopCountdown, pauseRequested, advanceToNext, handleWrong]);
 
@@ -304,6 +319,7 @@ export function useGauntletMode(allQuestions: Question[], options: GauntletModeO
     failedQuestion,
     failedAnswers,
     failedByTimeout,
+    lastPenalty,
     proceedToResults,
     continueAfterWrong,
   };

--- a/app/src/hooks/useTimeTrialMode.ts
+++ b/app/src/hooks/useTimeTrialMode.ts
@@ -28,10 +28,12 @@ interface TimeTrialState {
   lastAnswerCorrect: boolean | null;
 }
 
-const FEEDBACK_ADVANCE_DELAY = 1200;
+const FEEDBACK_ADVANCE_DELAY = 1800;
 
 /** Starting time in seconds. */
 export const INITIAL_TIME = 90;
+/** Maximum time allowed (cap). */
+export const MAX_TIME = 120;
 /** Seconds added for a correct answer. */
 export const CORRECT_BONUS = 15;
 /** Seconds subtracted for a wrong answer. */
@@ -106,15 +108,18 @@ export function useTimeTrialMode(allQuestions: Question[]) {
     setSelectedAnswers(new Set());
   }, []);
 
-  // Adjust timer by delta (positive = add, negative = subtract)
-  const adjustTime = useCallback((delta: number) => {
-    const newTime = Math.max(0, timeRemainingRef.current + delta);
+  // Adjust timer by delta (positive = add, negative = subtract), capped at [0, MAX_TIME].
+  // Returns the actual delta applied after clamping.
+  const adjustTime = useCallback((delta: number): number => {
+    const oldTime = timeRemainingRef.current;
+    const newTime = Math.min(MAX_TIME, Math.max(0, oldTime + delta));
     timeRemainingRef.current = newTime;
     setTimeRemaining(newTime);
     if (newTime <= 0) {
       stopCountdown();
       setState((prev) => ({ ...prev, phase: "game_over" }));
     }
+    return newTime - oldTime;
   }, [stopCountdown]);
 
   // Initialize / restart
@@ -206,6 +211,8 @@ export function useTimeTrialMode(allQuestions: Question[]) {
 
   const confirmAnswer = useCallback(() => {
     if (state.phase !== "playing" || !currentQuestion || !isAnswerComplete()) return;
+    // Guard: if timer already expired between render and click, bail out
+    if (timeRemainingRef.current <= 0) return;
 
     // Pause timer during feedback
     stopCountdown();
@@ -218,9 +225,9 @@ export function useTimeTrialMode(allQuestions: Question[]) {
       [...selectedAnswers].every((id) => correctIds.has(id));
 
     if (isCorrect) {
-      adjustTime(CORRECT_BONUS);
-      setTotalGained((prev) => prev + CORRECT_BONUS);
-      setLastDelta(CORRECT_BONUS);
+      const actual = adjustTime(CORRECT_BONUS);
+      setTotalGained((prev) => prev + actual);
+      setLastDelta(actual);
       setDeltaKey((prev) => prev + 1);
       setState((prev) => ({
         ...prev,
@@ -239,9 +246,9 @@ export function useTimeTrialMode(allQuestions: Question[]) {
       }, FEEDBACK_ADVANCE_DELAY);
     } else {
       // Wrong answer — subtract penalty, show review
-      adjustTime(-WRONG_PENALTY);
-      setTotalLost((prev) => prev + WRONG_PENALTY);
-      setLastDelta(-WRONG_PENALTY);
+      const actual = adjustTime(-WRONG_PENALTY);
+      setTotalLost((prev) => prev + Math.abs(actual));
+      setLastDelta(actual);
       setDeltaKey((prev) => prev + 1);
       setFailedQuestion(currentQuestion);
       setFailedAnswers(new Set(selectedAnswers));

--- a/app/src/hooks/useTimeTrialMode.ts
+++ b/app/src/hooks/useTimeTrialMode.ts
@@ -4,7 +4,8 @@
  * useTimeTrialMode — game engine hook for Time Trial.
  *
  * A single global countdown starts at INITIAL_TIME seconds.
- * Correct answers add CORRECT_BONUS seconds, wrong answers subtract
+ * Correct answers add CORRECT_BONUS seconds (or CORRECT_BONUS_MULTI for
+ * multi-select questions), wrong answers subtract
  * WRONG_PENALTY seconds. Timer reaches 0 → game over.
  * Score = total correct answers.
  *
@@ -34,8 +35,10 @@ const FEEDBACK_ADVANCE_DELAY = 1800;
 export const INITIAL_TIME = 90;
 /** Maximum time allowed (cap). */
 export const MAX_TIME = 120;
-/** Seconds added for a correct answer. */
+/** Seconds added for a correct single-select answer. */
 export const CORRECT_BONUS = 15;
+/** Seconds added for a correct multi-select answer. */
+export const CORRECT_BONUS_MULTI = 20;
 /** Seconds subtracted for a wrong answer. */
 export const WRONG_PENALTY = 5;
 
@@ -225,7 +228,8 @@ export function useTimeTrialMode(allQuestions: Question[]) {
       [...selectedAnswers].every((id) => correctIds.has(id));
 
     if (isCorrect) {
-      const actual = adjustTime(CORRECT_BONUS);
+      const bonus = currentQuestion.isMultiSelect ? CORRECT_BONUS_MULTI : CORRECT_BONUS;
+      const actual = adjustTime(bonus);
       setTotalGained((prev) => prev + actual);
       setLastDelta(actual);
       setDeltaKey((prev) => prev + 1);


### PR DESCRIPTION
This pull request introduces enhancements to both the Gauntlet and Time Trial challenge modes, focusing on improved feedback and more nuanced scoring logic. The main changes include partial credit for multi-select questions in Gauntlet mode, capping and tracking of time bonuses in Time Trial mode, and corresponding UI and test updates to support these features.

### Gauntlet Mode: Partial Credit and Feedback
* Added partial credit logic for multi-select questions: if a user selects at least 50% correct answers, only half a life is lost, otherwise a full life is lost. This is reflected in both the logic (`useGauntletMode`) and the feedback message shown to the user (`wrongHalfLifeLost`). [[1]](diffhunk://#diff-9d3a47d3052ce5605aff47cec809e2619b7a3e8f87e0798e6c55a72161fafea9R299-R413) [[2]](diffhunk://#diff-cf57989077c3966c340440050a5da91da9a6c2e8ea6c4ea5c2e71a10e61e591aR63) [[3]](diffhunk://#diff-29194d23e18c7bacc8ce3d60a846a113027677f334bbf87c1fce3643eb0d3145R53) [[4]](diffhunk://#diff-29194d23e18c7bacc8ce3d60a846a113027677f334bbf87c1fce3643eb0d3145L176-R179) [[5]](diffhunk://#diff-2a4a3db9c670b51deecf4c2afaefaba050203c0267fffceff458a77a00187102R197)
* Updated and expanded tests to cover partial credit, accumulation of half-life losses, and correct penalty application for both single- and multi-select questions.

### Time Trial Mode: Bonus Capping and Feedback
* Implemented a maximum cap (`MAX_TIME`) for the timer, so correct answers cannot increase the time above this limit. The feedback now reflects the actual seconds gained (which may be zero if at cap), and a new message is shown when the cap is reached. [[1]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L14-R14) [[2]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L327-R332) [[3]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44R373-R384) [[4]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L407-R413) [[5]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L416-R429) [[6]](diffhunk://#diff-2a4a3db9c670b51deecf4c2afaefaba050203c0267fffceff458a77a00187102L212-R215)
* Updated the UI to visually indicate when the timer is at maximum (using amber color and "MAX" label), and to display the actual seconds gained or lost after each answer. [[1]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44R373-R384) [[2]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L407-R413) [[3]](diffhunk://#diff-5b2ec8ce1e73c6bd9e6a62040978b8f090e636979562f56faf68957c2a6cdc44L416-R429)

### Test and Message Updates
* Added and updated tests for Time Trial mode to verify time capping, partial bonuses, and accurate tracking of total time gained/lost. [[1]](diffhunk://#diff-a07251f5ba1ed8d779341cfaa06af4cefe18ede3a9207edce732a1a4550c4498R7) [[2]](diffhunk://#diff-a07251f5ba1ed8d779341cfaa06af4cefe18ede3a9207edce732a1a4550c4498L200-R207) [[3]](diffhunk://#diff-a07251f5ba1ed8d779341cfaa06af4cefe18ede3a9207edce732a1a4550c4498L227-R228) [[4]](diffhunk://#diff-a07251f5ba1ed8d779341cfaa06af4cefe18ede3a9207edce732a1a4550c4498R273-R377)
* Updated translation strings and feedback messages to support new behaviors and dynamic values in both challenge modes. [[1]](diffhunk://#diff-2a4a3db9c670b51deecf4c2afaefaba050203c0267fffceff458a77a00187102R197) [[2]](diffhunk://#diff-2a4a3db9c670b51deecf4c2afaefaba050203c0267fffceff458a77a00187102L212-R215)

### UI Improvements
* Enhanced the `LivesDisplay` component to visually represent half-life losses with half-filled heart icons.

These changes provide a fairer scoring system for multi-select questions, clearer feedback for users, and a more polished and informative UI in both challenge modes.