### PR TITLE
actions/q-131: ADD Calling reusable workflow vs composite actions

### DIFF
--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -7,10 +7,10 @@ documentation: "https://docs.github.com/en/actions/concepts/workflows-and-action
 > As an action, composite actions must contain the brunt of their logic within an `action.yml` file. To call the composite action, point to where its `action.yml` is located (this includes the root. ex. to call a composite action that is located in the same repository as the caller workflow, the syntax `uses: ./` would be used).
 - [ ] Reusable workflows are called via referencing the folder that contains their `action.yml` file.
 > Reusable workflows are regular `.yml` or `.yaml` files that are stored in `.github/workflows`. They do not have an `action.yml` file.
-- [ ] Composite actions must be called directly from a job.
+- [ ] Composite actions must be called as a step within a job (not from step-level).
 > Composite actions (as with any other action) are called from within a __step__ of a workflow job--in other words, you do not need a specific workflow job just to caller a composite action. 
-- [x] Reusable workflows must be called directly from a job.
-> Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an indvidiual job within the caller workflow.  
+- [x] Reusable workflows must be called directly within a workflow job (not from step-level).
+> Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an indvidiual job within the caller workflow. This can result in one or more jobs running in the caller workflow (said jobs can be seen in workflow runs in the Github Actions UI). 
 - [ ] Secrets can be passed to both reusable workflows and calling composite actions via the `uses.secrets` block.
 > Only reusable workflows can be called using the `secrets` block. To pass secrets to a composite action, workarounds must be used (such as passing the secret as an input)
 - [ ] Only reusable workflows can accept inputs.

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -5,7 +5,7 @@ documentation: "https://docs.github.com/en/actions/concepts/workflows-and-action
 ---
 
 - [x] Composite actions are called via referencing the folder that contains their `action.yml` file.
-> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. The `action.yml` must reside in an `actions/<action-name>` subfolder.
+> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. The composite action's `action.yml` must reside in an `.github/actions/<action-name>` subfolder.
 - [ ] Reusable workflows are called via referencing the folder that contains their `action.yml` file.
 > Reusable workflows are regular `.yml` or `.yaml` files that are stored in `.github/workflows`. They do not have an `action.yml` file.
 - [ ] Composite actions must be called directly from a job.

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -4,7 +4,7 @@ documentation: "https://docs.github.com/en/actions/concepts/workflows-and-action
 ---
 
 - [x] Composite actions are called via referencing the folder that contains their `action.yml` file.
-> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. The composite action's `action.yml` must reside in an `.github/actions/<action-name>` subfolder.
+> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. To call the composite action, point to where its `action.yml` is located (this includes the root. ex. to call a composite action that is located in the same repository as the caller workflow, the syntax `uses: ./` would be used).
 - [ ] Reusable workflows are called via referencing the folder that contains their `action.yml` file.
 > Reusable workflows are regular `.yml` or `.yaml` files that are stored in `.github/workflows`. They do not have an `action.yml` file.
 - [ ] Composite actions must be called directly from a job.

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -4,12 +4,12 @@ documentation: "https://docs.github.com/en/actions/concepts/workflows-and-action
 ---
 
 - [x] Composite actions are called via referencing the folder that contains their `action.yml` file.
-> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. To call the composite action, point to where its `action.yml` is located (this includes the root. ex. to call a composite action that is located in the same repository as the caller workflow, the syntax `uses: ./` would be used).
+> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. To call the composite action, point to where its `action.yml` is located (this includes the root. ex. to call a composite action that is located at the root of the same repository as the caller workflow, the syntax `uses: ./` would be used).
 - [ ] Reusable workflows are called via referencing the folder that contains their `action.yml` file.
 > Reusable workflows are regular `.yml` or `.yaml` files that are stored in `.github/workflows`. They do not have an `action.yml` file.
-- [ ] Composite actions must be called as a step within a job (not from step-level).
-> Composite actions (as with any other action) are called from within a __step__ of a workflow job--in other words, you do not need a specific workflow job just to caller a composite action. 
-- [x] Reusable workflows must be called directly within a workflow job (not from step-level).
+- [x] Composite actions must be called as a step within a job
+> Composite actions (as with any other action) are called from within a step of a workflow job--in other words, you do not need a specific workflow job just to caller a composite action. 
+- [x] Reusable workflows must be called on workflow job level (not from step-level).
 > Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an indvidiual job within the caller workflow. This can result in one or more jobs running in the caller workflow (said jobs can be seen in workflow runs in the Github Actions UI). 
 - [ ] Secrets can be passed to both reusable workflows and calling composite actions via the `uses.secrets` block.
 > Only reusable workflows can be called using the `secrets` block. To pass secrets to a composite action, workarounds must be used (such as passing the secret as an input)

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -1,4 +1,3 @@
-
 ---
 question: "Which of the following are true regarding calling reusable workflows versus calling composite actions?"
 documentation: "https://docs.github.com/en/actions/concepts/workflows-and-actions/reusing-workflow-configurations#key-differences-between-reusable-workflows-and-composite-actions"

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -10,7 +10,7 @@ documentation: "https://docs.github.com/en/actions/concepts/workflows-and-action
 - [x] Composite actions must be called as a step within a job
 > Composite actions (as with any other action) are called from within a step of a workflow job--in other words, you do not need a specific workflow job just to caller a composite action. 
 - [x] Reusable workflows must be called on workflow job level (not from step-level).
-> Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an indvidiual job within the caller workflow. This can result in one or more jobs running in the caller workflow (said jobs can be seen in workflow runs in the Github Actions UI). 
+> Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an individual job within the caller workflow. This can result in one or more jobs running in the caller workflow (said jobs can be seen in workflow runs in the Github Actions UI). 
 - [ ] Secrets can be passed to both reusable workflows and calling composite actions via the `uses.secrets` block.
 > Only reusable workflows can be called using the `secrets` block. To pass secrets to a composite action, workarounds must be used (such as passing the secret as an input)
 - [ ] Only reusable workflows can accept inputs.

--- a/questions/en/actions/question-131.md
+++ b/questions/en/actions/question-131.md
@@ -1,0 +1,20 @@
+
+---
+question: "Which of the following are true regarding calling reusable workflows versus calling composite actions?"
+documentation: "https://docs.github.com/en/actions/concepts/workflows-and-actions/reusing-workflow-configurations#key-differences-between-reusable-workflows-and-composite-actions"
+---
+
+- [x] Composite actions are called via referencing the folder that contains their `action.yml` file.
+> As an action, composite actions must contain the brunt of their logic within an `action.yml` file. The `action.yml` must reside in an `actions/<action-name>` subfolder.
+- [ ] Reusable workflows are called via referencing the folder that contains their `action.yml` file.
+> Reusable workflows are regular `.yml` or `.yaml` files that are stored in `.github/workflows`. They do not have an `action.yml` file.
+- [ ] Composite actions must be called directly from a job.
+> Composite actions (as with any other action) are called from within a __step__ of a workflow job--in other words, you do not need a specific workflow job just to caller a composite action. 
+- [x] Reusable workflows must be called directly from a job.
+> Steps within a workflow job cannot call a reusable workflow. A reusable workflow must be called by an indvidiual job within the caller workflow.  
+- [ ] Secrets can be passed to both reusable workflows and calling composite actions via the `uses.secrets` block.
+> Only reusable workflows can be called using the `secrets` block. To pass secrets to a composite action, workarounds must be used (such as passing the secret as an input)
+- [ ] Only reusable workflows can accept inputs.
+> Both reusable workflows and composite inputs can accept inputs. 
+- [x] Reusable workflows can use a different runner type than the caller workflow, while composite actions cannot. 
+> Reusable workflows have jobs like any other workflow, and those jobs can specify different runner type via the `jobs.runs-on` key. Composite actions inherit the runner environment of their calling workflow job.


### PR DESCRIPTION
Narrowed this to focus on calling differences

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds question that goes over differences in calling a reusable workflow versus a composite action: step vs. job-level calls, how secrets are passed, how to reference the called entity (action.yml vs <workflow-name>.yml)
## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A