### PR TITLE
actions/q-134: ADD question on using GitHub Script

### DIFF
--- a/questions/en/actions/question-134.md
+++ b/questions/en/actions/question-134.md
@@ -1,15 +1,15 @@
 ---
-question: "How do you use Github Script in workflows?"
+question: "How do you run custom JavaScript scripts directly in a GitHub Actions workflow?"
 documentation: "https://github.com/marketplace/actions/github-script"
 ---
 
 - [x] Via the `actions/github-script` action
-> To use Github Script, you must call upon [`actions/github-script`](https://github.com/actions/github-script) 
-- [ ] By enabling its configuration in the Actions settings of a repository
-> There are no settings relating to Github Script in the Actions settings of a repository.
-- [ ] By enabling its configuration in the Actions settings of an organization
-> While you may have to enable settings like 'Allow actions created by Github' in an organization's Action settings to use official Github Actions, this is not only related to Github Script. 
+> `actions/github-script` allows you to write and leverage inline JavaScript to make API calls and access workflow context. To use `actions/github-script`, you call it like any other action as seen in the [documentation](https://github.com/actions/github-script) 
+- [ ] By enabling the 'Allow custom JavaScript scripts' configuration in the Actions settings of a repository
+> There is no 'Allow custom JavaScript scripts' configuration in the Actions settings of a repository.
+- [ ] By enabling the 'Allow custom JavaScript scripts' configuration in the Actions settings of an organization
+> There is no 'Allow custom JavaScript scripts' configuration in the Actions settings of a repository. While you may have to enable settings like 'Allow actions created by Github' in an organization's Action settings to use official Github Actions, this is not only related to `actions/github-script`. 
 - [ ] Write the contents of a script block to the `GITHUB_SCRIPT` environmental variable
 > `GITHUB_SCRIPT` is not a default Github Actions environmental variable. A list of default environmental variables can be found in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/variables)
 - [ ] In a JavaScript Action, set the `using` key to `'github-script'`
-> JavaScript Actions must have their `using` key set to `node*` where * is a supported version of Node.js.  Generally, JavaScript Actions do not have a huge need for Github Script.
+> JavaScript Actions must have their `using` key set to `node*` where * is a supported version of Node.js.  Generally, JavaScript Actions do not have a need for `actions/github-script`.

--- a/questions/en/actions/question-134.md
+++ b/questions/en/actions/question-134.md
@@ -1,0 +1,15 @@
+---
+question: "How do you use Github Script in workflows?"
+documentation: "https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions"
+---
+
+- [x] Via the `actions/github-script` action
+> To use Github Script, you must call upon [`actions/github-script`] (https://github.com/actions/github-script) 
+- [ ] By enabling its configuration in the Actions settings of a repository
+> There are no settings relating to Github Script in the Actions settings of a repository.
+- [ ] By enabling its configuration in the Actions settings of an organization
+> While you may have to enable settings like 'Allow actions created by Github' in an organization's Action settings to use official Github Actions, this is not only related to Github Script. 
+- [ ] Write the contents of a script block to the `GITHUB_SCRIPT` environmental variable
+> `GITHUB_SCRIPT` is not a default Github Actions environmental variable. A list of default environmental variables can be found in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/variables)
+- [ ] In a JavaScript Action, set the `using` key to `'github-script'`
+> JavaScript Actions must have their `using` key set to `node*` where * is a supported version of Node.js.  Generally, JavaScript Actions do not have a huge need for Github Script.

--- a/questions/en/actions/question-134.md
+++ b/questions/en/actions/question-134.md
@@ -1,10 +1,10 @@
 ---
 question: "How do you use Github Script in workflows?"
-documentation: "https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions"
+documentation: "https://github.com/marketplace/actions/github-script"
 ---
 
 - [x] Via the `actions/github-script` action
-> To use Github Script, you must call upon [`actions/github-script`] (https://github.com/actions/github-script) 
+> To use Github Script, you must call upon [`actions/github-script`](https://github.com/actions/github-script) 
 - [ ] By enabling its configuration in the Actions settings of a repository
 > There are no settings relating to Github Script in the Actions settings of a repository.
 - [ ] By enabling its configuration in the Actions settings of an organization


### PR DESCRIPTION
Note: Commit message moved to __What's new?__ section

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Add new question explaining how to use GitHub Script in workflows. The file:
- clarifies that the `actions/github-script` action must be used,
- shows that Github Script is not tied to repo or org setting,
- shows that Github Script  is not tied to env var,
- explains that JavaScript actions have to pertintent use of Github Script

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A

Another topic I'm not super familiar with. Github Script is mentioned on Microsoft's Github Actions cert practice exam--to be clear, this is NOT a copy of one of the exam questions--but not over here. I definitely need confirmation that this is all true, just let me know and I will make modifications if need be. Thanks!

Editted to add: 'Github Script' isn't a common term. It refers to `actions/github-script`