### PR TITLE
actions/q-135: ADD Forked repo workflows and secrets

### DIFF
--- a/questions/en/actions/question-135.md
+++ b/questions/en/actions/question-135.md
@@ -4,11 +4,11 @@ documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choos
 ---
 
 - [x] Forked repositories do not inherit secrets from the original repository  
-> As a security measure, (except for GITHUB_TOKEN) secrets are not passed to the runner when a workflow is triggered from a forked repository. This will result in the workflow failing if it references a secret from the original repository.
+> As a security measure, (except for `GITHUB_TOKEN`) secrets are not passed to the runner when a workflow is triggered from a forked repository. This will result in the workflow failing if it references a secret from the original repository.
 - [ ] When inheriting the secret from the original repository, there was an error during the fork that resulted in a malformed, invalid secret
-> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, no such malformation could occur.
+> Except for `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, no such malformation could occur.
 - [ ] The inherited secret had a size larger than 48 KB
-> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, size is not a factor to consider.
+> Except for `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, size is not a factor to consider.
 - [ ] Forked repositories only inherit repository secrets, so the secret being used in the workflow must have been an organizational or environment secret.
-> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. This applies to all types of secrets (repository, environment, and organizational).
+> Except for `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. This applies to all types of secrets (repository, environment, and organizational).
 

--- a/questions/en/actions/question-135.md
+++ b/questions/en/actions/question-135.md
@@ -1,0 +1,14 @@
+---
+question: "You have forked a repository to enhance a workflow that uses a secret to access a third-party application. You trigger the workflow before editing its code to get a baseline result, but find that the workflow fails. Why would this occur? "
+documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets?tool=webui#using-secrets-in-a-workflow"
+---
+
+- [x] Forked repositories do not inherit secrets from the original repository  
+> As a security measure, (except for GITHUB_TOKEN) secrets are not passed to the runner when a workflow is triggered from a forked repository. This will result in the workflow failing if it references a secret from the original repository.
+- [ ] When inheriting the secret from the original repository, there was an error during the fork that resulted in a malformed, invalid secret
+> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, no such malformation could occur.
+- [ ] The inherited secret had a size >48 KB
+> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, size is not a factor to consider.
+- [ ] Forked repositories only inherit repository secrets, so the secret being used in the workflow must have been an organizational or environment secret.
+> Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. This applies to all types of secrets (repository, environment, and organizational).
+

--- a/questions/en/actions/question-135.md
+++ b/questions/en/actions/question-135.md
@@ -7,7 +7,7 @@ documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choos
 > As a security measure, (except for GITHUB_TOKEN) secrets are not passed to the runner when a workflow is triggered from a forked repository. This will result in the workflow failing if it references a secret from the original repository.
 - [ ] When inheriting the secret from the original repository, there was an error during the fork that resulted in a malformed, invalid secret
 > Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, no such malformation could occur.
-- [ ] The inherited secret had a size >48 KB
+- [ ] The inherited secret had a size larger than 48 KB
 > Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. Thus, size is not a factor to consider.
 - [ ] Forked repositories only inherit repository secrets, so the secret being used in the workflow must have been an organizational or environment secret.
 > Except for GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. This applies to all types of secrets (repository, environment, and organizational).

--- a/questions/en/actions/question-135.md
+++ b/questions/en/actions/question-135.md
@@ -1,5 +1,5 @@
 ---
-question: "You have forked a repository to enhance a workflow that uses a secret to access a third-party application. You trigger the workflow before editing its code to get a baseline result, but find that the workflow fails. Why would this occur? "
+question: "You have forked a repository to enhance a workflow that uses a secret to access a third-party application. You trigger the workflow before editing its code to get a baseline result, but find that the workflow fails. Why would this occur?"
 documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets?tool=webui#using-secrets-in-a-workflow"
 ---
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a question regarding secret usage in a forked repository workflow. 

The question could probably be shortened, I'm just trying to think of a better way to word it while still getting the point across that the workflow's code hasn't changed since the initial fork. 

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A