### PR TITLE
fix: shuffle answers in Question Browser & document behavior

### DIFF
--- a/app/src/app/[locale]/questions/[cert]/question-browser.tsx
+++ b/app/src/app/[locale]/questions/[cert]/question-browser.tsx
@@ -7,13 +7,14 @@
  *   Left: compact numbered grid for quick navigation
  *   Right: question card with answer options, check/reveal, prev/next
  *
- * Stateless — no scoring, no flagging, no shuffling, no results screen.
+ * Stateless — no scoring, no flagging, no results screen.
+ * Answer order is shuffled on mount (client-side) to prevent position memorization.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import type { Question } from "@/types/quiz";
-import { cn } from "@/lib/utils";
+import { cn, shuffle } from "@/lib/utils";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
@@ -32,6 +33,17 @@ export function QuestionBrowser({ questions }: QuestionBrowserProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState<Record<string, Set<string>>>({});
   const [revealedMap, setRevealedMap] = useState<Record<number, boolean>>({});
+
+  // Shuffle answers per question on mount (client-only to avoid hydration mismatch)
+  const [shuffledAnswerMap, setShuffledAnswerMap] = useState<Record<string, Question["answers"]>>({});
+  useEffect(() => {
+    const map: Record<string, Question["answers"]> = {};
+    for (const q of questions) {
+      map[q.id] = shuffle(q.answers);
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- shuffle must run client-side only to avoid hydration mismatch
+    setShuffledAnswerMap(map);
+  }, [questions]);
 
   // Sidebar pagination — auto-follows active question, manual override resets on question nav
   const PAGE_SIZE = 20;
@@ -53,8 +65,15 @@ export function QuestionBrowser({ questions }: QuestionBrowserProps) {
     });
   }, []);
 
-  const currentQuestion = questions[currentIndex];
-  const currentSelected = selectedAnswers[currentQuestion?.id] ?? new Set<string>();
+  const currentQuestion = useMemo(() => {
+    const q = questions[currentIndex];
+    if (!q) return null;
+    const shuffledAnswers = shuffledAnswerMap[q.id];
+    // Return null until shuffle is ready to prevent flash of unshuffled answers
+    if (!shuffledAnswers) return null;
+    return { ...q, answers: shuffledAnswers };
+  }, [questions, currentIndex, shuffledAnswerMap]);
+  const currentSelected = selectedAnswers[currentQuestion?.id ?? ""] ?? new Set<string>();
   const isRevealed = revealedMap[currentIndex] || false;
 
   const handleToggleAnswer = useCallback(

--- a/questions/README.md
+++ b/questions/README.md
@@ -68,6 +68,10 @@ Use Markdown list items with checkboxes. Mark correct answers with `[x]`, incorr
 
 Aim for 2–6 answer options.
 
+### Answer ordering
+
+Answers are automatically shuffled in the application . You don't need to worry about the position of correct answers in your markdown file. Placing correct answers first (as shown in the examples above) is a recommended practice to improve readability.
+
 ### Answer explanations
 
 Add a blockquote (`>`) on the line immediately after an answer to explain why it's correct or incorrect. These are optional and help learners understand the reasoning.


### PR DESCRIPTION
## Summary

Adds answer shuffling to the Question Browser and documents the behavior for question writers.

### Changes

1. **Question Browser** — Answers are now shuffled on mount (client-side via `useEffect`) to prevent position memorization. Questions remain in file-system order for deterministic browsing. A loading guard prevents any flash of unshuffled content.

2. **Question Writing Guide** — Added "Answer ordering" section confirming answers are shuffled across all experiences, so writers can place correct answers first for readability.

### Context

Previously, practice tests and challenge modes shuffled both questions and answers, but the Question Browser showed answers in their authored (markdown) order. This meant users could memorize answer positions when studying via the browser.

The `useEffect` + `setState` pattern is the established best practice in this codebase (and Next.js generally) for client-only randomization that avoids hydration mismatch.

Closes #641