### PR TITLE
chore: update mdquiz to 0.2.1 and remove hint field

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,7 +15,7 @@
         "clsx": "^2.1.1",
         "deepmerge": "^4.3.1",
         "lucide-react": "^1.9.0",
-        "mdquiz": "^0.1.1",
+        "mdquiz": "^0.2.1",
         "motion": "^12.38.0",
         "next": "16.2.4",
         "next-intl": "^4.9.1",
@@ -8552,9 +8552,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/mdquiz": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/mdquiz/-/mdquiz-0.1.1.tgz",
-      "integrity": "sha512-aXSmrr4qqvvqHlOKkYWIwro820brqvA9cnopkeys0dsYsRZaoDaFtFvUwMgK/0RyWYKZudLmPYIMqsWph1GLGg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mdquiz/-/mdquiz-0.2.1.tgz",
+      "integrity": "sha512-/VcLTW56ubLQOh61bRdWNzN31x0KDm+ZufOd1+t1riCKCvXdckijW47huTIoarDwuYoOgZr9hG7ykHelstmxAg==",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3"
@@ -9575,6 +9575,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "clsx": "^2.1.1",
     "deepmerge": "^4.3.1",
     "lucide-react": "^1.9.0",
-    "mdquiz": "^0.1.1",
+    "mdquiz": "^0.2.1",
     "motion": "^12.38.0",
     "next": "16.2.4",
     "next-intl": "^4.9.1",

--- a/app/src/lib/__tests__/cross-locale.test.ts
+++ b/app/src/lib/__tests__/cross-locale.test.ts
@@ -36,7 +36,6 @@ interface ParsedQuestion {
   question: string;
   answers: { text: string; isCorrect: boolean }[];
   isMultiSelect: boolean;
-  hint?: string;
   frontmatter: Record<string, unknown>;
 }
 

--- a/app/src/lib/questions.ts
+++ b/app/src/lib/questions.ts
@@ -25,7 +25,6 @@ export interface Question {
   question: string;
   answers: { id: string; text: string; isCorrect: boolean; explanation?: string }[];
   isMultiSelect: boolean;
-  hint?: string;
   codeBlock?: string;
   documentation?: string;
 }
@@ -91,7 +90,6 @@ function loadAll(locale: SupportedLocale): Question[] {
         question: q.question,
         answers: q.answers,
         isMultiSelect: q.isMultiSelect,
-        hint: q.hint,
         codeBlock: q.codeBlock,
         documentation: q.frontmatter.documentation as string | undefined,
       });


### PR DESCRIPTION
## Changes

- Bump `mdquiz` from `0.1.1` to `0.2.1`
- Remove `hint` property from `Question` interface (removed upstream in mdquiz)
- Remove hint mapping in question loader
- Remove hint from cross-locale test type

No UI components were using `hint`, so this is a clean removal with no functional impact.