### PR TITLE
actions/q-138: ADD question r/t workflow_run trig

### DIFF
--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -8,6 +8,7 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 - [ ] `workflow_trigger`
 > There is no such event trigger
 - [ ] `workflow_dispatch`
-> `workflow_dispatch` is used for manually triggering a workflow. See [the documentation] for more info.(https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) is
+> `workflow_dispatch` is used for manually triggering a workflow. See [the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) for more info.
 - [ ] `workflow_call`
-> `workflow_call` is used so a workflow can be called from other workflows or actions. See [the documentation] for more info.(https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) 
+> `workflow_call` is used so a workflow can be called from other workflows or actions. See [the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) 
+ for more info.

--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -10,5 +10,4 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 - [ ] `workflow_dispatch`
 > `workflow_dispatch` is used for manually triggering a workflow. See [the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) for more info.
 - [ ] `workflow_call`
-> `workflow_call` is used so a workflow can be called from other workflows or actions. See [the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) 
- for more info.
+> `workflow_call` is used so a workflow can be called from other workflows or actions. See [the documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) for more info.

--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -8,6 +8,6 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 - [ ] `workflow_trigger`
 > There is no such event trigger
 - [ ] `workflow_dispatch`
-> `workflow_dispatch` is used for manually triggering a workflow.
+> [`workflow_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) is used for manually triggering a workflow.
 - [ ] `workflow_call`
-> `workflow_call` is used so a workflow can be called from other workflows or actions. 
+> [`workflow_call`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) is used so a workflow can be called from other workflows or actions. 

--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -8,6 +8,6 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 - [ ] `workflow_trigger`
 > There is no such event trigger
 - [ ] `workflow_dispatch`
-> [`workflow_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) is used for manually triggering a workflow.
+> `workflow_dispatch` is used for manually triggering a workflow. See [the documentation] for more info.(https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) is
 - [ ] `workflow_call`
-> [`workflow_call`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) is used so a workflow can be called from other workflows or actions. 
+> `workflow_call` is used so a workflow can be called from other workflows or actions. See [the documentation] for more info.(https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) 

--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -4,7 +4,7 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 ---
 
 - [x] `workflow_run`
-> `workflow_run` allows you to specify what other workflows (once completed, regardless of success) should trigger your workflow. Note that while this question specifically asks about completed workflows, `workflow_run` can also be oriented to trigger your workflow when other specified workflows have been triggered or started processing on a runner
+> `workflow_run` allows you to trigger a workflow once other specified workflows have completed (regardless of success). Note that while this question specifically asks about completed workflows, `workflow_run` can also be oriented to trigger a workflow when other specified workflows have been triggered or started processing on a runner
 - [ ] `workflow_trigger`
 > There is no such event trigger
 - [ ] `workflow_dispatch`

--- a/questions/en/actions/question-138.md
+++ b/questions/en/actions/question-138.md
@@ -1,0 +1,13 @@
+---
+question: "You want to create a workflow `Post-Deploy` that performs post-deploy related activity. What event trigger should the `Post-Deploy` workflow use so it runs automatically after a specified workflow is completed?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run"
+---
+
+- [x] `workflow_run`
+> `workflow_run` allows you to specify what other workflows (once completed, regardless of success) should trigger your workflow. Note that while this question specifically asks about completed workflows, `workflow_run` can also be oriented to trigger your workflow when other specified workflows have been triggered or started processing on a runner
+- [ ] `workflow_trigger`
+> There is no such event trigger
+- [ ] `workflow_dispatch`
+> `workflow_dispatch` is used for manually triggering a workflow.
+- [ ] `workflow_call`
+> `workflow_call` is used so a workflow can be called from other workflows or actions. 


### PR DESCRIPTION
Note: Commit message taken and moved to **__What's New?__** section
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new Q&A file (questions/en/actions/question-138.md) that asks which Actions event should be used to run a Post-Deploy workflow automatically after another workflow completes. The file explains that:
- `workflow_run` is used to trigger a workflow after other specified workflows have completed
- In an explanation, also notes that `workflow_run` can be used when other specified workflows have been triggered or are in progress

Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations
## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A