### PR TITLE
actions/q-139: ADD question regarding runner diagnostic logging

### DIFF
--- a/questions/en/actions/question-139.md
+++ b/questions/en/actions/question-139.md
@@ -1,10 +1,14 @@
 ---
-question: "How can you enable runner diagnostic logging?"
+question: "In what ways can you enable runner diagnostic logging?"
 documentation: "https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging"
 ---
 
-- [x] 
-> This matrix produces 5 jobs with the following matrix combinations:
-- []
-- []
-- []
+- [x] Setting a secret or variable named `ACTIONS_RUNNER_DEBUG` to `true`
+> Note: This secret or variable can be defined at organization or repository level.
+- [x] Re-running a workflow with `Enable debug logging enabled`
+- [] By adding a `runner-diagnostic-logs` top-level folder to the workflow's repository
+> `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
+- [] By adding a `runner-diagnostic-logs` subfolder to the `_diag` directory of the self-hosted runner being used
+> `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
+- [] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`
+> Renaming the `_diag` directory should never be done as this can potentially effect logging activities.

--- a/questions/en/actions/question-139.md
+++ b/questions/en/actions/question-139.md
@@ -4,7 +4,7 @@ documentation: "https://docs.github.com/en/actions/how-tos/monitor-workflows/ena
 ---
 
 - [x] Setting a secret or variable named `ACTIONS_RUNNER_DEBUG` to `true`
-> Note: This secret or variable can be defined at organization or repository level.
+> Note: `ACTIONS_RUNNER_DEBUG` can be set as a secret or variable at organization-level or repository-level.
 - [x] Re-running a workflow with `Enable debug logging enabled`
 - [] By adding a `runner-diagnostic-logs` top-level folder to the workflow's repository
 > `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 

--- a/questions/en/actions/question-139.md
+++ b/questions/en/actions/question-139.md
@@ -6,8 +6,7 @@ documentation: "https://docs.github.com/en/actions/how-tos/monitor-workflows/ena
 - [x] Setting a secret or variable named `ACTIONS_RUNNER_DEBUG` to `true`
 > Note: `ACTIONS_RUNNER_DEBUG` can be set as a secret or variable at organization-level or repository-level.
 - [x] Re-running a workflow with `Enable debug logging enabled`
-- [ ] By adding a `runner-diagnostic-logs` top-level folder to the workflow's repository
-> `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
+- [ ] By adding a `ACTIONS_RUNNER_DEBUG` top-level folder to the workflow's repository
 - [ ] By adding a `runner-diagnostic-logs` subfolder to the `_diag` directory of the self-hosted runner being used
 > `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
 - [ ] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`

--- a/questions/en/actions/question-139.md
+++ b/questions/en/actions/question-139.md
@@ -6,9 +6,9 @@ documentation: "https://docs.github.com/en/actions/how-tos/monitor-workflows/ena
 - [x] Setting a secret or variable named `ACTIONS_RUNNER_DEBUG` to `true`
 > Note: `ACTIONS_RUNNER_DEBUG` can be set as a secret or variable at organization-level or repository-level.
 - [x] Re-running a workflow with `Enable debug logging enabled`
-- [] By adding a `runner-diagnostic-logs` top-level folder to the workflow's repository
+- [ ] By adding a `runner-diagnostic-logs` top-level folder to the workflow's repository
 > `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
-- [] By adding a `runner-diagnostic-logs` subfolder to the `_diag` directory of the self-hosted runner being used
+- [ ] By adding a `runner-diagnostic-logs` subfolder to the `_diag` directory of the self-hosted runner being used
 > `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
-- [] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`
+- [ ] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`
 > Renaming the `_diag` directory should never be done as this can potentially effect logging activities.

--- a/questions/en/actions/question-139.md
+++ b/questions/en/actions/question-139.md
@@ -1,0 +1,10 @@
+---
+question: "How can you enable runner diagnostic logging?"
+documentation: "https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging"
+---
+
+- [x] 
+> This matrix produces 5 jobs with the following matrix combinations:
+- []
+- []
+- []


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a question about how to enable runner diagnostic logging. Explains that:
-  a [repo/org] secret or variable `ACTIONS_RUNNER_DEBUG` set to `true` enables the extra logging. **Note:** I tested this on organization level to be sure. The documentation doesn't word it as such (makes it sound like it MUST be a repo secret/var), but I opened an issue with them to make the wording more explicit.
-  Re-running with debug enabled also enables the logging

Also adds explanatory notes about the auto-generated runner-diagnostic-logs folder and warn against renaming the self-hosted runner's `_diag` directory.

Was able to test locally:

Styling looks good
Confirmed documentation link works and leads to proper location

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
