### PR TITLE
actions/q-140: ADD question regarding built-in startsWith fxn

### DIFF
--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -1,0 +1,23 @@
+---
+question: "You are writing a reusable workflow which has `branch_name` as an input. How can you conditionally run a step in that workflow if the branch begins with 'smoke-test'?"
+documentation: "TODO"
+---
+
+- [ ] 
+```yaml
+    if: startsWith(inputs.branch_name, 'smoke-test')
+```
+> Note: `ACTIONS_RUNNER_DEBUG` can be set as a secret or variable at organization-level or repository-level.
+- [ ] 
+- [ ]
+```yaml
+on:
+  workflow_call:
+    branches:
+        - 'smoke-test/**'
+```
+> `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
+- [ ]
+> `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
+- [ ] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`
+> Renaming the `_diag` directory should never be done as this can potentially effect logging activities.

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -7,10 +7,12 @@ documentation: "TODO"
 ```yaml
     if: startsWith(inputs.branch-name, 'smoke-test')
 ```
+
 - [ ]
 ```yaml
     if: inputs.branch-name.startsWith('smoke-test')
 ``` 
+
 - [ ]
 ```yaml
 on:
@@ -19,6 +21,7 @@ on:
         - 'smoke-test/**'
 ```
 > `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
+
 - [ ]
 ```yaml
     if: [[ "${{inputs.branch-name}}" == "smoke-test"* ]]

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -3,12 +3,12 @@ question: "You are writing a reusable workflow which has `branch-name` as an inp
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#startswith"
 ---
 
-- [x] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if` as seen below
+- [x] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if`
 ```yaml
     if: startsWith(inputs.branch-name, 'smoke-test')
 ```
 
-- [ ] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if` as seen below
+- [ ] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if`
 ```yaml
     if: inputs.branch-name.startsWith('smoke-test')
 ``` 
@@ -22,7 +22,7 @@ on:
 ```
 > `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
 
-- [ ] Use shell conditionals in combination with `jobs.<job_id>.steps[*].if` as seen below
+- [ ] Use shell conditionals in combination with `jobs.<job_id>.steps[*].if`
 ```yaml
     if: [[ "${{inputs.branch-name}}" == "smoke-test"* ]]
 ```

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -12,7 +12,7 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 ```yaml
     if: inputs.branch-name.startsWith('smoke-test')
 ``` 
-
+> You cannot use method chaining with Github Actions built-in methods. Almost all built-in methods are written in the style of `methodName(arg1,arg2,...)` 
 - [ ] Use the `branches` filter under `workflow_call`
 ```yaml
 on:

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -3,17 +3,17 @@ question: "You are writing a reusable workflow which has `branch-name` as an inp
 documentation: "TODO"
 ---
 
-- [x] 
+- [x] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if` as seen below
 ```yaml
     if: startsWith(inputs.branch-name, 'smoke-test')
 ```
 
-- [ ]
+- [ ] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if` as seen below
 ```yaml
     if: inputs.branch-name.startsWith('smoke-test')
 ``` 
 
-- [ ]
+- [ ] Use the `branches` filter under `workflow_call`
 ```yaml
 on:
   workflow_call:
@@ -22,7 +22,7 @@ on:
 ```
 > `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
 
-- [ ]
+- [ ] Use shell conditionals in combination with `jobs.<job_id>.steps[*].if` as seen below
 ```yaml
     if: [[ "${{inputs.branch-name}}" == "smoke-test"* ]]
 ```

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -20,7 +20,7 @@ on:
     branches:
         - 'smoke-test/**'
 ```
-> `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
+> `branches` filter is not available for `workflow_call` event trigger. Furthermore, workflow event triggers can't be used to control whether a step runs or not
 
 - [ ] Use shell conditionals in combination with `jobs.<job_id>.steps[*].if`
 ```yaml

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -1,14 +1,16 @@
 ---
-question: "You are writing a reusable workflow which has `branch_name` as an input. How can you conditionally run a step in that workflow if the branch begins with 'smoke-test'?"
+question: "You are writing a reusable workflow which has `branch-name` as an input. How can you conditionally run a step in that workflow if the branch name begins with 'smoke-test'?"
 documentation: "TODO"
 ---
 
-- [ ] 
+- [x] 
 ```yaml
-    if: startsWith(inputs.branch_name, 'smoke-test')
+    if: startsWith(inputs.branch-name, 'smoke-test')
 ```
-> Note: `ACTIONS_RUNNER_DEBUG` can be set as a secret or variable at organization-level or repository-level.
-- [ ] 
+- [ ]
+```yaml
+    if: inputs.branch-name.startsWith('smoke-test')
+``` 
 - [ ]
 ```yaml
 on:
@@ -18,6 +20,7 @@ on:
 ```
 > `branches` is not a child of `workflow_call`. Furthermore, `workflow_call` is at workflow-level; items at this level cannot directly cause a step to run/not run.
 - [ ]
-> `runner-diagnostic-logs` is the name of the folder Github generates when `ACTIONS_RUNNER_DEBUG` is enabled. To avoid potential confusion, a folder with this name should not be created anywhere else. 
-- [ ] Renaming the `_diag` directory of a self-hosted runner to `runner-diagnostic-logs`
-> Renaming the `_diag` directory should never be done as this can potentially effect logging activities.
+```yaml
+    if: [[ "${{inputs.branch-name}}" == "smoke-test"* ]]
+```
+> Only supported Github Actions contexts and expressions can be used in `jobs.<job_id>.steps[*].if` conditonals. 

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -26,4 +26,4 @@ on:
 ```yaml
     if: [[ "${{inputs.branch-name}}" == "smoke-test"* ]]
 ```
-> Only supported Github Actions contexts and expressions can be used in `jobs.<job_id>.steps[*].if` conditonals. 
+> Only supported Github Actions contexts and expressions can be used in `jobs.<job_id>.steps[*].if` conditionals. 

--- a/questions/en/actions/question-140.md
+++ b/questions/en/actions/question-140.md
@@ -1,6 +1,6 @@
 ---
 question: "You are writing a reusable workflow which has `branch-name` as an input. How can you conditionally run a step in that workflow if the branch name begins with 'smoke-test'?"
-documentation: "TODO"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#startswith"
 ---
 
 - [x] Use the built-in `startsWith` method in combination with `jobs.<job_id>.steps[*].if` as seen below


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->


Adds a question regarding how to validate an input starts with a specified string:
- Shows that `startsWith` should be used (one incorrect answer uses `startsWith` but with improper syntax)
- One incorrect answer's explanation explains that shell conditionals (using a Bash example) are NOT supported within `jobs.<job_id>.steps[*].if`

Was able to test locally:

Styling looks good
Confirmed documentation link works and leads to proper location
Confirmed the veracity of the correct answer by spooling up a quick [dummy workflow](https://github.com/org-mushroom-kingdom/ttn-workflows/actions/workflows/builtin-functions-test.yml)

It's a simple one, but part of an ongoing effort I'm starting to learn more about built-in Github Actions functions. As always, let me know if anything looks amiss/rewording is desired. Thanks!

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A
