### PR TITLE
actions/q-142: ADD question r/t installation access tokens

### DIFF
--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -5,7 +5,7 @@ documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticat
 
 - [x] Installation access tokens are short-lived tokens ideal for automation activities, but require setting up a Github App.
 - [x] `GITHUB_TOKEN` is a type of installation access token.
-> `GITHUB_TOKEN` is a GitHub App installation access token that is set up when you enable Github Actions. See the  [documentation](https://docs.github.com/en/actions/concepts/security/github_token) for additional details.
+> `GITHUB_TOKEN` is a GitHub App installation access token that is automatically generated for every workflow run. See the  [documentation](https://docs.github.com/en/actions/concepts/security/github_token) for additional details.
 - [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
 - [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
 > Once created, an installation access can be used immediately. See the [official page for this action](https://github.com/actions/create-github-app-token) for additional details.

--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -8,6 +8,6 @@ documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticat
 > `GITHUB_TOKEN` is a GitHub App installation access token that is set up when you enable Github Actions. See the  [documentation](https://docs.github.com/en/actions/concepts/security/github_token) for additional details.
 - [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
 - [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
-> Once created, an installation access can be used immediately. See the [documentation](https://github.com/actions/create-github-app-token) for additional details.
+> Once created, an installation access can be used immediately. See the [offical page for this action](https://github.com/actions/create-github-app-token) for additional details.
 - [ ] Installation access tokens are similar to personal access tokens (PATs) in that both are tied to a specific user account
 > Installation access tokens act on behalf of their associated Github App, not a user account.

--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -8,6 +8,6 @@ documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticat
 > `GITHUB_TOKEN` is a GitHub App installation access token that is set up when you enable Github Actions. See the  [documentation](https://docs.github.com/en/actions/concepts/security/github_token) for additional details.
 - [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
 - [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
-> Once created, an installation access can be used immediately. See the [offical page for this action](https://github.com/actions/create-github-app-token) for additional details.
+> Once created, an installation access can be used immediately. See the [official page for this action](https://github.com/actions/create-github-app-token) for additional details.
 - [ ] Installation access tokens are similar to personal access tokens (PATs) in that both are tied to a specific user account
 > Installation access tokens act on behalf of their associated Github App, not a user account.

--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -9,5 +9,5 @@ documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticat
 - [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
 - [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
 > Once created, an installation access can be used immediately. See the [official page for this action](https://github.com/actions/create-github-app-token) for additional details.
-- [ ] Installation access tokens are similar to personal access tokens (PATs) in that both are tied to a specific user account
-> Installation access tokens act on behalf of their associated Github App, not a user account.
+- [ ] Installation access tokens cannot be configued to act on behalf of their associated Github App. 
+> Installation access tokens are often configured to act on behalf of their associated Github App. This can aid in auditing automated activity.

--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -1,0 +1,13 @@
+---
+question: "Which of the following answers is correct regarding installation access tokens?"
+documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#using-an-installation-access-token-to-authenticate-as-an-app-installation"
+---
+
+- [x] Installation access tokens are short-lived tokens ideal for automation activities, but require setting up a Github App.
+- [x] `GITHUB_TOKEN` is a type of installation access token.
+> `GITHUB_TOKEN` is a GitHub App installation access token that is set up when you enable Github Actions. See the  [documentation](https://docs.github.com/en/actions/concepts/security/github_token) for additional details.
+- [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
+- [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
+> Once created, an installation access can be used immediately. See the [documentation](https://github.com/actions/create-github-app-token) for additional details.
+- [ ] Installation access tokens are similar to personal access tokens (PATs) in that both are tied to a specific user account
+> Installation access tokens act on behalf of their associated Github App, not a user account.

--- a/questions/en/actions/question-142.md
+++ b/questions/en/actions/question-142.md
@@ -9,5 +9,5 @@ documentation: "https://docs.github.com/en/apps/creating-github-apps/authenticat
 - [x] The `actions/create-github-app-token` can be called within workflows to create an installation access token available for immediate use. 
 - [ ] The `actions/create-github-app-token` can be called within workflows to create an installation access token, but the installation access token can only be used in future runs of the workflow.
 > Once created, an installation access can be used immediately. See the [official page for this action](https://github.com/actions/create-github-app-token) for additional details.
-- [ ] Installation access tokens cannot be configued to act on behalf of their associated Github App. 
+- [ ] Installation access tokens cannot be configured to act on behalf of their associated Github App. 
 > Installation access tokens are often configured to act on behalf of their associated Github App. This can aid in auditing automated activity.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Introduce a new question covering installation access tokens for GitHub Apps:
- Notes short lifespan and requirement of Github App setup
- Notes GITHUB_TOKEN being an installation access token
- Informs immediate usability of tokens created by actions/create-github-app-token,
- Notes that installation tokens act on behalf of a GitHub App (with links to relevant docs).

Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations

This is kind of a niche topic, so let me know if you think it's worth including. Also, annoyingly, the page with the section "About installation access tokens" (see [here](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#about-installation-access-tokens)) doesn't mention that much about them, so the documentation link points to another reference that _does_ list characteristics regarding installation access tokens, but this information is scattered throughout the instructions. 

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
