### PR TITLE
actions/q-143: ADD question r/t Artifact retention period modification (org-level)

### DIFF
--- a/questions/en/actions/question-143.md
+++ b/questions/en/actions/question-143.md
@@ -1,5 +1,5 @@
 ---
-question: "Your organization wants to lower the retention period for stored artifacts. How can this be done at an organizational level?"
+question: "Your organization wants to lower the retention period for stored artifacts, citing storage concerns. How can this be done at an organizational level?"
 documentation: "https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization"
 ---
 

--- a/questions/en/actions/question-143.md
+++ b/questions/en/actions/question-143.md
@@ -1,0 +1,11 @@
+---
+question: "Your organization wants to lower the retention period for stored artifacts. How can this be done at an organizational level?"
+documentation: "https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization"
+---
+
+- [x] By navigating to the organization's Actions settings and editing the value of the "Artifact and log retention" setting
+- [ ] By using self-hosted runners, creating a `.github/retention-policy.yml` file, and specifying the value of the `artifact-retention-period` key 
+> Customizing artifact retention periods is not limited to self-hosted runners.  
+- [ ] This cannot be done at an organizational level. All workflows that utilize `actions/upload-artifact` must use the required `retention-days` input.
+> While the `retention-days` input can be used to customize the retention period for individual artifacts created by a workflow, this is inappropriate if trying to apply an organizational level blanket policy. Furthermore, the `retention-days` input is [optional, not required](https://github.com/actions/upload-artifact#inputs).
+- [ ] This cannot be done: artifacts are strictly stored for 90 days across all systems implementing Github Actions. 

--- a/questions/en/actions/question-143.md
+++ b/questions/en/actions/question-143.md
@@ -9,3 +9,4 @@ documentation: "https://docs.github.com/en/organizations/managing-organization-s
 - [ ] This cannot be done at an organizational level. All workflows that utilize `actions/upload-artifact` must use the required `retention-days` input.
 > While the `retention-days` input can be used to customize the retention period for individual artifacts created by a workflow, this is inappropriate if trying to apply an organizational level blanket policy. Furthermore, the `retention-days` input is [optional, not required](https://github.com/actions/upload-artifact#inputs).
 - [ ] This cannot be done: artifacts are strictly stored for 90 days across all systems implementing Github Actions. 
+> The default retention period for artifacts is 90 days. It is possible to change this value in all systems implementing Github Actions. 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add question on org-level artifact retention
Introduce a new question that asks how to lower artifact retention at the organization level:
- The correct option of going to the organization's Actions settings ('Artifact and log retention') is covered
- Establishes the difference between organizational artifact retention settings vs. individual workflow/artifact settings ( actions/upload-artifact`retention-days`) along with an explanation link to help further discern between the two
- Explanations help reinforce artifact retention settings are possible across various implementations of Github Actions

### Testing Details

Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes 

This is niche, but probably good to have. In particular, focusing specifically on org-level artifact retention modification is useful as a similar concept exists at the workflow-level. Let me know about the wording and any suggestions you have in regards to it 

I'll have a question that's similar to this as a sort of follow-up (i.e. focuses on changing artifact retention periods on the workflow/artifact level as opposed to an organization policy)

Thanks as always! 
## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A