### PR TITLE
actions/q-147: ADD question r/t add-mask

### DIFF
--- a/questions/en/actions/question-147.md
+++ b/questions/en/actions/question-147.md
@@ -1,12 +1,12 @@
 ---
 question: "You have a base-64 encoded secret that you decode in a GitHub Actions workflow. How can you make sure the decoded secret does not show up in the workflow log accidentally?"
-documentation: "https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log"
 ---
 
 - [x] Using `add-mask` in jobs where the decoded secret may be utilized.
 > Using `add-mask` will redact values Github Actions does not detect as a secret. This needs to be done once per value, per job that utilizes the decoded secret.
 - [ ] Nothing needs to be done since Github Actions infrastructure automatically redacts decoded secrets.
-> It is not guaranteed that Github Actions will be able to automatically detect and redact transformed secrets per the [documentation](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information).   
+> It is not guaranteed that Github Actions will be able to automatically detect and redact transformed secrets per the [documentation](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information).  
 - [ ] Avoiding the usage of print statements that contain the decoded secret, since this is the only way the decoded secret could appear in the workflow log
 > While avoiding print statements that contain decoded secrets is recommended, decoded secrets may appear elsewhere in the workflow log, such as in messages relating to API calls.
 - [ ] Using the built-in `addMask` function to redact the decoded secret in instances where it may be utilized.

--- a/questions/en/actions/question-147.md
+++ b/questions/en/actions/question-147.md
@@ -3,7 +3,7 @@ question: "You have a base-64 encoded secret that you decode in a GitHub Actions
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log"
 ---
 
-- [x] Using `add-mask` in jobs where the decoded secret may be utilized.
+- [x] Using `add-mask` workflow command in jobs where the decoded secret may be utilized.
 > Using `add-mask` will redact values Github Actions does not detect as a secret. This needs to be done once per value, per job that utilizes the decoded secret.
 - [ ] Nothing needs to be done since Github Actions infrastructure automatically redacts decoded secrets.
 > It is not guaranteed that Github Actions will be able to automatically detect and redact transformed secrets per the [documentation](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information).  

--- a/questions/en/actions/question-147.md
+++ b/questions/en/actions/question-147.md
@@ -9,5 +9,5 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 > It is not guaranteed that Github Actions will be able to automatically detect and redact transformed secrets per the [documentation](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information).  
 - [ ] Avoiding the usage of print statements that contain the decoded secret, since this is the only way the decoded secret could appear in the workflow log
 > While avoiding print statements that contain decoded secrets is recommended, decoded secrets may appear elsewhere in the workflow log, such as in messages relating to API calls.
-- [ ] Using the built-in `addMask` function to redact the decoded secret in instances where it may be utilized.
-> `addMask` is not a built-in function provided by Github Actions.
+- [ ] Using the built-in `maskSecret` function to redact the decoded secret in instances where it may be utilized.
+> `maskSecret` is not a built-in function provided by Github Actions.

--- a/questions/en/actions/question-147.md
+++ b/questions/en/actions/question-147.md
@@ -1,0 +1,13 @@
+---
+question: "You have a base-64 encoded secret that you decode in a GitHub Actions workflow. How can you make sure the decoded secret does not show up in the workflow log accidentally?"
+documentation: "https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information"
+---
+
+- [x] Using `add-mask` in jobs where the decoded secret may be utilized.
+> Using `add-mask` will redact values Github Actions does not detect as a secret. This needs to be done once per value, per job that utilizes the decoded secret.
+- [ ] Nothing needs to be done since Github Actions infrastructure automatically redacts decoded secrets.
+> It is not guaranteed that Github Actions will be able to automatically detect and redact transformed secrets per the [documentation](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information).   
+- [ ] Avoiding the usage of print statements that contain the decoded secret, since this is the only way the decoded secret could appear in the workflow log
+> While avoiding print statements that contain decoded secrets is recommended, decoded secrets may appear elsewhere in the workflow log, such as in messages relating to API calls.
+- [ ] Using the built-in `addMask` function to redact the decoded secret in instances where it may be utilized.
+> `addMask` is not a built-in function provided by Github Actions.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question elaborating on add-mask behavior:
- Explains that base64-decoded secrets should be redacted using `add-mask` (once per value, per job)
- Explains that transformed secrets will not always be automatically redacted
- Clarifies that Actions may not auto-redact transformed secrets, (with relevant doc link)
- Explains why avoiding print statements is insufficient, as secrets can be exposed other ways

### Testing Details
Styling looks good
All links confirmed to work and lead to proper locations

### Other Notes

Let me know about the verbiage. I did confirm independently that add-mask needs to be done once per value per job via a workflow run you can see in my repo, ttn-workflows [here](https://github.com/org-mushroom-kingdom/ttn-workflows/actions/runs/25649532260/job/75284904345). The documentation doesn't specifically say this explicitly, but I also raised a PR over there to make it so they do and hopefully it gets merged in soon.

Thanks!

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A