### PR TITLE
Filter bot contributors using API type field instead of hardcoded list

### DIFF
--- a/app/src/lib/contributors.ts
+++ b/app/src/lib/contributors.ts
@@ -1,10 +1,4 @@
 const REPO = "FidelusAleksander/ghcertified";
-const BOT_LOGINS = new Set([
-  "dependabot[bot]",
-  "github-actions[bot]",
-  "imgbot[bot]",
-  "Copilot",
-]);
 
 export interface Contributor {
   login: string;
@@ -30,10 +24,11 @@ export async function getContributors(): Promise<Contributor[]> {
     avatar_url: string;
     html_url: string;
     contributions: number;
+    type: string;
   }> = await res.json();
 
   return data
-    .filter((c) => !BOT_LOGINS.has(c.login))
+    .filter((c) => c.type !== "Bot")
     .map((c) => ({
       login: c.login,
       avatarUrl: c.avatar_url,


### PR DESCRIPTION
Bot accounts like `ghcertified-auto-translate[bot]` were appearing in the homepage contributor list because the hardcoded `BOT_LOGINS` set didn't include them.

Instead of maintaining a list of bot logins, this filters on the `type` field from the GitHub API response — bot accounts return `type: "Bot"`. This is future-proof and requires no maintenance when new bots are added to the repo.

### Changes
- **`app/src/lib/contributors.ts`** — Replace `BOT_LOGINS` set with `c.type !== "Bot"` filter; add `type` to API response type
