### PR TITLE
actions/q-149: ADD q r/t GITHUB_STEP_SUMMARY

### DIFF
--- a/questions/en/actions/question-149.md
+++ b/questions/en/actions/question-149.md
@@ -5,7 +5,7 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 
 ```yaml
 - name: "Write results of test suite"
-  run:
+  run: |
     echo "The results of the testing suite are:" >> $GITHUB_STEP_SUMMARY
 ```
 - [x] Adds this line to the job summary

--- a/questions/en/actions/question-149.md
+++ b/questions/en/actions/question-149.md
@@ -1,0 +1,16 @@
+---
+question: "What does writing to `GITHUB_STEP_SUMMARY` do?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary"
+---
+
+```yaml
+- name: "Write results of test suite"
+  run:
+    echo "The results of the testing suite are:" >> $GITHUB_STEP_SUMMARY
+```
+- [x] Adds this line to the job summary
+> Writing to `GITHUB_STEP_SUMMARY` adds to the job summary, which can be used as a streamlined version of a workflow log.
+- [ ] Adds this line as a subtitle to the step name in the GitHub Actions UI
+- [ ] Adds this line to the built-in artifact `github-steps-summary.md`
+- [ ] Prints this line as a step-level debug message
+> To print a debug message in a step, you must use the `::debug::` syntax. See the "Setting a debug message" section in the linked documentation.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Create a new question explaining what writing to GITHUB_STEP_SUMMARY does:
- Explains that writing to GITHUB_STEP_SUMMARY appends content to the job summary in GitHub Actions.
- Clarifies the correct way to print debug messages

### Testing Details
Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes

Let me know if the correct answer should be more embellished, or if desired, I should create a question like "How can you add to a job summary?"

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
