### PR TITLE
actions/q-150: ADD questions r/t github.event object

### DIFF
--- a/questions/en/actions/question-150.md
+++ b/questions/en/actions/question-150.md
@@ -3,9 +3,9 @@ question: "Edelgard is troubleshooting a workflow triggered by a push event and 
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context"
 ---
 
-- [ ] Using the `github.event` object
+- [x] Using the `github.event` object
 > `github.event` will show the full event webhook payload. This payload varies upon the type of event. See the [Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads) for more details.
-- [ ] Using the `github.event_payload` object
+- [ ] Checking the "Show event webhook payload" checkbox under the workflow run options.
 - [ ] Setting a secret or variable named `SHOW_EVENT_PAYLOAD` to `true`
-- [ ] Navigating to the "Webhooks" section of the repository settings. 
+- [ ] Navigating to the "Webhooks" section of the repository settings 
 > The "Webhooks" section in repository settings will only show details for custom webhooks, not standard event webhooks like `push`. 

--- a/questions/en/actions/question-150.md
+++ b/questions/en/actions/question-150.md
@@ -3,7 +3,7 @@ question: "Dorothea is troubleshooting a workflow triggered by a push event and 
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context"
 ---
 
-- [x] Using the `github.event` object
+- [x] Printing the contents of the `github.event` object in a step
 > `github.event` will show the full event webhook payload. This payload varies upon the type of event. See the [Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads) for more details.
 - [ ] Checking the "Show event webhook payload" checkbox under the workflow run options.
 - [ ] Setting a secret or variable named `SHOW_EVENT_PAYLOAD` to `true`

--- a/questions/en/actions/question-150.md
+++ b/questions/en/actions/question-150.md
@@ -1,0 +1,11 @@
+---
+question: "Edelgard is troubleshooting a workflow triggered by a push event and is interested in seeing details about the webhook. How can she view the entire payload of the webhook that triggered the workflow?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context"
+---
+
+- [ ] Using the `github.event` object
+> `github.event` will show the full event webhook payload. This payload varies upon the type of event. See the [Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads) for more details.
+- [ ] Using the `github.event_payload` object
+- [ ] Setting a secret or variable named `SHOW_EVENT_PAYLOAD` to `true`
+- [ ] Navigating to the "Webhooks" section of the repository settings. 
+> The "Webhooks" section in repository settings will only show details for custom webhooks, not standard event webhooks like `push`. 

--- a/questions/en/actions/question-150.md
+++ b/questions/en/actions/question-150.md
@@ -1,5 +1,5 @@
 ---
-question: "Edelgard is troubleshooting a workflow triggered by a push event and is interested in seeing details about the webhook. How can she view the entire payload of the webhook that triggered the workflow?"
+question: "Dorothea is troubleshooting a workflow triggered by a push event and is interested in seeing details about the webhook. How can she view the entire payload of the webhook that triggered the workflow?"
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context"
 ---
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a new related to what github.event is:
- Explains that github.event allows one to view the full webhook payload that triggered a workflow.
- Clarifies that repository "Webhooks" settings only shows custom webhook details, not standard ones.

### Testing Details
Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
