### PR TITLE
feat: add Agentic AI Developer (GH-600) certification (beta)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,10 @@ copilot:
 - changed-files:
   - any-glob-to-any-file: "questions/en/copilot/*"
 
+agentic:
+- changed-files:
+  - any-glob-to-any-file: "questions/en/agentic/*"
+
 translations:
 - changed-files:
   - any-glob-to-any-file:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Pick the certification and name your file `question-XXX.md`, where `XXX` is the 
 | Actions | `questions/en/actions/` |
 | Admin | `questions/en/admin/` |
 | Advanced Security | `questions/en/advanced_security/` |
+| Agentic AI Developer | `questions/en/agentic/` |
 | Copilot | `questions/en/copilot/` |
 | Foundations | `questions/en/foundations/` |
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -227,6 +227,7 @@
     "actions": "Master CI/CD, workflow triggers, jobs, steps, secrets, and GitHub-hosted runners.",
     "foundations": "Core concepts, repositories, issues, pull requests, GitHub Flow, and Codespaces.",
     "advanced_security": "Secret scanning, code scanning with CodeQL, security policies, and Dependabot alerts.",
+    "agentic": "Operating, integrating, and governing AI agents in SDLC workflows using GitHub as the control plane.",
     "admin": "Managing organizations, teams, permissions, billing, and enterprise-level GitHub.",
     "copilot": "AI pair programming, prompt engineering, Copilot features, and responsible use."
   },

--- a/app/src/app/[locale]/practice-tests/catalog-cards.tsx
+++ b/app/src/app/[locale]/practice-tests/catalog-cards.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Slider } from "@/components/ui/slider";
+import { Badge } from "@/components/ui/badge";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { CERT_META } from "@/lib/cert-meta";
 
@@ -63,9 +64,16 @@ export function CatalogCards({ certs, locale }: Props) {
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-3">
-                      <h3 className="font-display text-lg font-bold text-foreground tracking-tight leading-tight">
-                        {cert.name}
-                      </h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-display text-lg font-bold text-foreground tracking-tight leading-tight">
+                          {cert.name}
+                        </h3>
+                        {meta.beta && (
+                          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-semibold">
+                            Beta
+                          </Badge>
+                        )}
+                      </div>
                       <ChevronDown className={`
                         size-4 text-muted-foreground/60 flex-shrink-0 transition-transform duration-200
                         ${isExpanded ? "rotate-180" : "group-hover:text-muted-foreground"}

--- a/app/src/app/[locale]/practice-tests/catalog-cards.tsx
+++ b/app/src/app/[locale]/practice-tests/catalog-cards.tsx
@@ -69,7 +69,7 @@ export function CatalogCards({ certs, locale }: Props) {
                           {cert.name}
                         </h3>
                         {meta.beta && (
-                          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 font-semibold">
+                          <Badge className="text-[10px] px-2 py-0.5 font-bold bg-blue-500/15 text-blue-600 dark:text-blue-400 border border-blue-500/30">
                             Beta
                           </Badge>
                         )}

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -55,6 +55,7 @@
   --color-cert-actions: var(--cert-actions);
   --color-cert-foundations: var(--cert-foundations);
   --color-cert-advanced-security: var(--cert-advanced-security);
+  --color-cert-agentic: var(--cert-agentic);
   --color-cert-admin: var(--cert-admin);
   --color-cert-copilot: var(--cert-copilot);
   --color-hover-ring: var(--primary-soft);
@@ -120,6 +121,7 @@
   --cert-actions: hsl(220 100% 55%);
   --cert-foundations: hsl(157 74% 41%);
   --cert-advanced-security: hsl(269 67% 52%);
+  --cert-agentic: hsl(187 85% 43%);
   --cert-admin: hsl(27 90% 47%);
   --cert-copilot: hsl(0 0% 6%);
 }

--- a/app/src/lib/cert-meta.tsx
+++ b/app/src/lib/cert-meta.tsx
@@ -13,7 +13,7 @@ import {
   ShieldLockIcon,
   OrganizationIcon,
   CopilotIcon,
-  HubotIcon,
+  AgentIcon,
 } from "@primer/octicons-react";
 import type { CertificationType } from "./questions";
 
@@ -48,7 +48,7 @@ export const CERT_META: Record<CertificationType, CertMeta> = {
     colorClass: "bg-cert-agentic",
     borderClass: "border-cert-agentic",
     textClass: "text-cert-agentic",
-    icon: <HubotIcon size={24} className="text-primary-foreground" />,
+    icon: <AgentIcon size={24} className="text-primary-foreground" />,
     beta: true,
   },
   admin: {

--- a/app/src/lib/cert-meta.tsx
+++ b/app/src/lib/cert-meta.tsx
@@ -13,6 +13,7 @@ import {
   ShieldLockIcon,
   OrganizationIcon,
   CopilotIcon,
+  HubotIcon,
 } from "@primer/octicons-react";
 import type { CertificationType } from "./questions";
 
@@ -21,6 +22,7 @@ export interface CertMeta {
   borderClass: string;
   textClass: string;
   icon: React.ReactNode;
+  beta?: boolean;
 }
 
 export const CERT_META: Record<CertificationType, CertMeta> = {
@@ -41,6 +43,13 @@ export const CERT_META: Record<CertificationType, CertMeta> = {
     borderClass: "border-cert-advanced-security",
     textClass: "text-cert-advanced-security",
     icon: <ShieldLockIcon size={24} className="text-primary-foreground" />,
+  },
+  agentic: {
+    colorClass: "bg-cert-agentic",
+    borderClass: "border-cert-agentic",
+    textClass: "text-cert-agentic",
+    icon: <HubotIcon size={24} className="text-primary-foreground" />,
+    beta: true,
   },
   admin: {
     colorClass: "bg-cert-admin",

--- a/app/src/lib/questions.ts
+++ b/app/src/lib/questions.ts
@@ -16,6 +16,7 @@ export type CertificationType =
   | "actions"
   | "admin"
   | "advanced_security"
+  | "agentic"
   | "copilot"
   | "foundations";
 
@@ -54,12 +55,13 @@ export const CERT_TITLES: Record<CertificationType, string> = {
   actions: "GitHub Actions (GH-200)",
   admin: "GitHub Administration (GH-100)",
   advanced_security: "GitHub Advanced Security (GH-500)",
+  agentic: "GitHub Agentic AI Developer (GH-600)",
   copilot: "GitHub Copilot (GH-300)",
   foundations: "GitHub Foundations (GH-900)",
 };
 
 const VALID_CERTS: CertificationType[] = [
-  "actions", "admin", "advanced_security", "copilot", "foundations",
+  "actions", "admin", "advanced_security", "agentic", "copilot", "foundations",
 ];
 
 export { VALID_CERTS };

--- a/cspell.json
+++ b/cspell.json
@@ -33,6 +33,7 @@
     "VCS",
     "DVCS",
     "relref",
-    "rerequested"
+    "rerequested",
+    "frontmatter"
   ]
 }

--- a/questions/README.md
+++ b/questions/README.md
@@ -10,6 +10,7 @@ This guide covers everything you need to write questions for [ghcertified](https
   - `questions/en/actions/`
   - `questions/en/admin/`
   - `questions/en/advanced_security/`
+  - `questions/en/agentic/`
   - `questions/en/copilot/`
   - `questions/en/foundations/`
 

--- a/questions/en/agentic/question-001.md
+++ b/questions/en/agentic/question-001.md
@@ -1,0 +1,13 @@
+---
+question: "In a custom agent profile for GitHub Copilot, which top-level YAML frontmatter key is used to declare MCP servers that the agent can access?"
+documentation: "https://docs.github.com/en/copilot/reference/custom-agents-configuration"
+---
+
+- [x] `mcp-servers`
+> The `mcp-servers` key defines MCP server configurations including type, command, args, tools, and environment variables.
+- [ ] `tools`
+> `tools` lists which tools the agent can use, but does not define MCP server configurations itself.
+- [ ] `servers`
+> There is no `servers` key in the custom agent YAML schema.
+- [ ] `extensions`
+> `extensions` is not a valid key in the custom agent profile frontmatter.

--- a/questions/en/agentic/question-002.md
+++ b/questions/en/agentic/question-002.md
@@ -1,0 +1,13 @@
+---
+question: "Which GitHub CLI command starts a new Copilot cloud agent session to work on a task autonomously?"
+documentation: "https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/create-a-pr"
+---
+
+- [x] `gh agent-task create`
+> `gh agent-task create` (requires GitHub CLI v2.80.0+) starts a cloud agent session that can create branches and pull requests.
+- [ ] `gh copilot agent start`
+> This command does not exist in the GitHub CLI.
+- [ ] `gh workflow run copilot-agent`
+> This would run a GitHub Actions workflow, not a Copilot cloud agent session.
+- [ ] `gh issue assign --copilot`
+> While you can assign issues to Copilot via the API, this is not the correct CLI command syntax.


### PR DESCRIPTION
## Summary

Adds the new **GitHub Agentic AI Developer (GH-600)** certification to the platform, scaffolded as a beta with initial seed questions.

## Changes

### Infrastructure
- Added `"agentic"` to `CertificationType` union, `CERT_TITLES`, and `VALID_CERTS`
- Created `questions/en/agentic/` directory for question contributions
- Added `HubotIcon` + cyan color (`hsl(187 85% 43%)`) in `cert-meta.tsx` and `globals.css`
- Added `CertDescriptions.agentic` in `app/messages/en.json`
- Updated `questions/README.md` with new directory listing

### UI
- Added `beta?: boolean` field to `CertMeta` interface
- Certification card shows a prominent blue **"Beta"** badge when `meta.beta` is true

### Content
- `question-001.md` — MCP server declaration in custom agent YAML profiles
- `question-002.md` — `gh agent-task create` for cloud agent sessions

## Context

The [GitHub Agentic AI Developer certification (Exam GH-600)](https://techcommunity.microsoft.com/blog/skills-hub-blog/new-github-certified-agentic-ai-developer/4517571) launched in beta on May 13, 2026. GA is expected July 2026.

Questions target the highest-weighted exam domain: "Implement tool use and environment interaction" (20–25%), sourced from official GitHub documentation.

## Verification
- ✅ `npm run build` passes (static export with new cert + 2 questions)
- ✅ `npm test` — all 87 tests pass
