### PR TITLE
actions/q-151: ADD question r/t GITHUB_ENV vs job outputs

### DIFF
--- a/questions/en/actions/question-151.md
+++ b/questions/en/actions/question-151.md
@@ -3,8 +3,8 @@ question: "Which should you use when passing information between jobs: job outpu
 documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#passing-values-between-steps-and-jobs-in-a-workflow"
 ---
 
-- [x] Job outputs, because the value of environmental variables set via `GITHUB_ENV` only applies to the current job.
-> While `env` can be set at workflow-level (meaning its variables can be used by multiple jobs), this does not mean changing the value of the environmental variable persists beyond the job that changed it.
+- [x] Job outputs, because the value of environmental variables set via writing to `GITHUB_ENV` only applies to the current job.
+> While `env` can be set at workflow-level (meaning its variables can be referenced by multiple jobs), this does not mean changing the value of the environmental variable persists beyond the job that changed it.
 - [ ] `GITHUB_ENV`, because job outputs can only be set and referenced within the same job.
 - [ ] Job outputs, because they are simpler to set up
 > Setting up and referencing job outputs is more complicated than utilizing `GITHUB_ENV`. For example, job outputs require setting up an `outputs` block, adding an `id` to a step, and using `needs` to indicate dependencies.

--- a/questions/en/actions/question-151.md
+++ b/questions/en/actions/question-151.md
@@ -1,0 +1,11 @@
+---
+question: "Which should you use when passing information between jobs: job outputs or `GITHUB_ENV`?"
+documentation: "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#passing-values-between-steps-and-jobs-in-a-workflow"
+---
+
+- [x] Job outputs, because the value of environmental variables set via `GITHUB_ENV` only applies to the current job.
+> While `env` can be set at workflow-level (meaning its variables can be used by multiple jobs), this does not mean changing the value of the environmental variable persists beyond the job that changed it.
+- [ ] `GITHUB_ENV`, because job outputs can only be set and referenced within the same job.
+- [ ] Job outputs, because they are simpler to set up
+> Setting up and referencing job outputs is more complicated than utilizing `GITHUB_ENV`. For example, job outputs require setting up an `outputs` block, adding an `id` to a step, and using `needs` to indicate dependencies.
+- [ ] `GITHUB_ENV`, because using it to set environmental variables puts significantly less strain on the runner, reducing workflow runtime.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds new question regarding job outputs vs GITHUB_ENV to pass data between jobs;
- Clarifies that values set via GITHUB_ENV only apply to the current job
- Corresponding explanation embellishes on the above
- Another explanation details why job outputs are more complicated to use than GITHUB_ENV

### Testing Details

Was able to test locally:

Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes

The purpose of this question is to solidify that job outputs should be used to pass information between jobs. This fact isn't immediately obvious to users, because GITHUB_ENV vars can be set at workflow-level and variables in it can be overwritten. This could make one think that they could substitute GITHUB_ENV/env usage for what job outputs do. 

That being said, I'm having a little trouble trying to convey that idea into the answers and explanations of this question. I think it sounds *okay* but any suggestions you might have would be great!

- Let me know about the correct answer's wording
- Let me know about the correct answer's corresponding explanation.
- Let me know if the third answer's explanation is too verbose (wanted to give some examples WHY job outputs are more complex to set up, but they might not be necessary)
## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
