### PR TITLE
actions/q-152: ADD question r/t self-hosted runners and tools cache

### DIFF
--- a/questions/en/actions/question-152.md
+++ b/questions/en/actions/question-152.md
@@ -1,0 +1,11 @@
+---
+question: "Fill in the blank: When using self-hosted runners, the tool cache ___"
+documentation: "https://docs.github.com/en/enterprise-server/admin/managing-github-actions-for-your-enterprise/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access"
+---
+
+- [x] starts off empty and must be populated in order to save tools between runs
+> Tool caches allow you to to cache different versions of tools, which enables faster self-hosted runner activity. Without tool caches, self-hosted runners that use `actions/setup-*` will take longer to execute.
+- [ ] starts off the same as GitHub-hosted runners in that it is pre-populated with certain tools
+> While GitHub-hosted runners do come with certain tools pre-installed, this is not the case for self-hosted runners
+- [ ] starts with the same tools GitHub-hosted runners do, as well as a selected assortment of custom tools to enhance self-hosted runner management
+- [ ] cannot be populated


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a new question that asks how the tool cache behaves on self-hosted runners:
- Clarifies that the tool cache starts off empty and must be populated to persist tools between runs
- Clariifies that GitHub-hosted runners come with some tools pre-installed

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes

The [Microsoft study guide](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-200) for the GitHub Actions exam mentions tool caches, but this is a frustrating question to compose on account of:
1. The study guide doesn't go into what they are at all nor what should be known about them
2. Official GitHub documentation about tool caches is lacking (there's a [community discussion](https://github.com/orgs/community/discussions/160668) about it)

Let me know if you can add anything to this. I can't reliably look at self-hosted runner tool caches since I don't have self-hosted runners set up

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A