### PR TITLE
actions/q-153: ADD q r/t triggering workflow on non-default branch

### DIFF
--- a/questions/en/actions/question-153.md
+++ b/questions/en/actions/question-153.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of the following events can trigger a workflow that has not been merged to the default branch?"
-documentation: "https://docs.github.com/en/enterprise-server/admin/managing-github-actions-for-your-enterprise/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access"
+documentation: ""
 ---
 
 - [x] `workflow_dispatch`

--- a/questions/en/actions/question-153.md
+++ b/questions/en/actions/question-153.md
@@ -3,11 +3,10 @@ question: "Which of the following events can trigger a workflow that has not bee
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request"
 ---
 
-- [x] `workflow_dispatch`
-> Note that while `workflow_dispatch` can be used to trigger the workflow from a non-default branch, the workflow must be triggered by some other event (i.e. `push`, `pull_request`) first. Also, note that `workflow_dispatch` must be triggered via the GitHub API or GitHub CLI, as the UI option will be unavailable since the workflow is not merged in the default branch.
 - [x] `push`
 - [x] `pull_request`
 > To trigger a workflow via `pull_request` the branch containing the workflow must be the target branch of the pull request.
+- [ ] `repository_dispatch`
 - [ ] `star`
 - [ ] `issues`
 - [ ] `issue_comment`

--- a/questions/en/actions/question-153.md
+++ b/questions/en/actions/question-153.md
@@ -1,0 +1,13 @@
+---
+question: "Which of the following events can trigger a workflow that has not been merged to the default branch?"
+documentation: "https://docs.github.com/en/enterprise-server/admin/managing-github-actions-for-your-enterprise/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access"
+---
+
+- [x] `workflow_dispatch`
+> Note that while `workflow_dispatch` can be used to trigger the workflow from a non-default branch, the workflow must be triggered by some other event (i.e. `push`, `pull_request`) first. Also, note that `workflow_dispatch` must be triggered via the GitHub API or GitHub CLI, as the UI option will be unavailable since the workflow is not merged in the default branch.
+- [x] `push`
+- [x] `pull_request`
+> To trigger a workflow via `pull_request` the branch containing the workflow must be the target branch of the pull request.
+- [ ] `star`
+- [ ] `issues`
+- [ ] `issue_comment`

--- a/questions/en/actions/question-153.md
+++ b/questions/en/actions/question-153.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of the following events can trigger a workflow that has not been merged to the default branch?"
-documentation: ""
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request"
 ---
 
 - [x] `workflow_dispatch`


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add new question detailing which selected events can trigger a workflow not merged into the default branch:
- Clarifies that workflow_dispatch, push, and pull_request are valid triggers
- Notes that workflow_dispatch works, but only after the workflow has been triggered in some other way (in an explanation)
- Notes that workflow_dispatch must be invoked via the API/CLI (UI unavailable for unmerged workflows) (in an explanation)
- Notes that pull_request triggers require the branch that contains the workflow to be the target branch of the pull request (in an explanation)

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes

None of these are well documented but I think this is important to note. Although the lack of documentation makes me think this might not be tested for? I am not sure. 

- Let me know if you think there's a better source because the one I'm using in `documentation` really only points to `pull_request`. 
- `workflow_dispatch` does work in the way I described in the answer--however, the docs don't detail this. **Note: This answer has since been removed**
- `push` is the easiest way to do this
- I don't want to self-promote and it also isn't an official GitHub source, but I do have an [article](https://levelup.gitconnected.com/triggering-a-github-actions-workflow-without-merging-into-the-default-branch-a-guide-8a2265aba998) I wrote that goes over various, evidence-backed ways to trigger a workflow that isn't merged to the default branch. It's not official documentation, but it's very thorough (shocking!). I have real examples that prove those methods work. Alternatively, we could link to GitHub community discussions which aren't "official" in the traditional sense, but I know there's stuff out there to an extent that details how to trigger a workflow when it's not merged in the default branch.

I digress though. Just let me know. Thanks!

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A