### PR TITLE
actions/q-156: ADD question r/t deleting workflow artifacts

### DIFF
--- a/questions/en/actions/question-156.md
+++ b/questions/en/actions/question-156.md
@@ -3,7 +3,7 @@ question: "In what ways can you delete workflow artifacts?"
 documentation: "https://docs.github.com/en/actions/how-tos/manage-workflow-runs/remove-workflow-artifacts"
 ---
 
-- [x] By using the Github Actions UI to navigate to a workflow run and delete the artifacts indvidually
+- [x] By using the Github Actions UI to navigate to a workflow run and delete the artifacts individually
 - [x] By using the Github Actions UI to delete the workflow run that generated the artifacts
 > Deleting a workflow run also deletes the artifacts associated with the run. 
 - [x] By using a specific GitHub API endpoint

--- a/questions/en/actions/question-156.md
+++ b/questions/en/actions/question-156.md
@@ -1,0 +1,15 @@
+---
+question: "In what ways can you delete workflow artifacts?"
+documentation: "https://docs.github.com/en/actions/how-tos/manage-workflow-runs/remove-workflow-artifacts"
+---
+
+- [x] By using the Github Actions UI to navigate to a workflow run and delete the artifacts indvidually
+- [x] By using the Github Actions UI to delete the workflow run that generated the artifacts
+> Deleting a workflow run also deletes the artifacts associated with the run. 
+- [x] By using a specific GitHub API endpoint
+> The Github API has a "Delete an artifact" endpoint. See the [documentation](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2026-03-10#delete-an-artifact) for more details.
+- [ ] By using the `actions/delete-artifact` action in a workflow 
+- [ ] By remotely accessing self-hosted runners via SSH, navigating to the `.github/artifacts` directory, and deleting the selected artifacts
+> Artifacts are generally stored using GitHub infrastructure, not runners. 
+- [ ] By setting the artifact retention period to 0 days
+> Artifact retention periods cannot be set to 0 days. See the [documentation](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) for more information.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a new question regarding ways to delete GitHub Actions workflow artifacts:
- Explains artifacts can be selectively deleted using the Actions UI
- Explains deleting the workflow run also deletes the associated artifacts
- Explains that the GitHub API has a Delete an artifact endpoint
- Clarifies that artifacts are stored via GitHub infrastructure, not in runners
- Clarifies that the artifact retention period cannot be 0 days

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes
Used the term "GitHub infrastructure" since I can't find a source stating that it's explicitly GitHub cloud storage

## Related issue(s)
<!-- If applicable link to related issues -->
N/A

## Screenshots
<!-- (optional) Include related screenshots -->
N/A