### PR TITLE
actions/q-158: ADD question r/t pr merge trigger

### DIFF
--- a/questions/en/actions/question-158.md
+++ b/questions/en/actions/question-158.md
@@ -1,0 +1,54 @@
+---
+question: "Petra is building a workflow whose sole job is named `post-merge`. How can she set up the job to be triggered upon a merged pull request?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges"
+---
+
+- [x]  Specify the `pull_request` activity type as `closed`, and use a job-level conditional to check if `github.event.pull_request.merged` is true
+```yaml
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    post-merge:
+        if: github.event.pull_request.merged == true
+``` 
+> To trigger a workflow job when a pull request is merged, you must specify both the activity type of the pull request in `on:` and set a job-level conditional.
+- [ ]  Specify the `pull_request` activity type as `merged`, and use a job-level conditional to check if `github.event.pull_request.merged` is true
+```yaml
+on:
+    pull_request:
+        types: [merged]
+jobs:
+    post-merge:
+        if: github.event.pull_request.merged == true
+``` 
+> The `pull_request` event does not have a `merged` activity type. See the "pull_request" section of the linked documentation to see the valid activity types for `pull_request`
+- [ ]  Specify the `pull_request` activity type as `merged` (no need for a job-level conditional)
+```yaml
+on:
+    pull_request:
+        types: [merged]
+jobs:
+    post-merge:
+``` 
+> The `pull_request` event does not have a `merged` activity type.
+- [ ] Specify the the `pull_request` activity type as `closed` (no need for a job-level conditional)
+```yaml
+on:
+    pull_request:
+        types: [closed]
+jobs:
+    post-merge:
+``` 
+> Pull requests can be closed without being merged. If you do not use a corresponding job-level conditional that checks whether the PR was merged, then the job will fire any time a PR is closed, not just when merging occurred.
+- [ ]  Specify the the `pull_request` activity type as `closed` and use a job-level conditional to check if `github.ref` is equal to the merge branch of the pull request.
+```yaml
+on:
+    pull_request:
+        types: [closed]
+jobs:
+    post-merge: 
+        if: ${{ github.ref == github.event.pull_request.base.ref }}
+``` 
+> After after a pull request has been merged, `github.ref` will be the *fully-formed ref* of the merge branch (ex. `refs/heads/main`), not simply the merge branch (ex. `main`). 


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a new question explaining how to trigger a workflow job when a pull request is merged:
- Clarifies that both on: pull_request, types: [closed] AND a job-level conditional if: github.event.pull_request.merged == true must be used to properly trigger a workflow(job) on a pull request merge
- Clarifies that `merged` is not a valid activity type for pull_request
- Explains that on: pull_request, types: [closed] is not sufficient and is too "eager" (i.e. it will trigger on merged PR's but also when any PR is closed)
- One wrong answer's explanation explains what the value of github.ref would be post-merge and that this value is similar but not the same to the merge branch

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes
Put stars around "fully-formed ref" in attempt to italicize, which didn't work (just shows stars, i.e. `*fully-formed ref*`. However, I think this still works in emphasizing that github.ref will be the ref of the target branch which is similar but not the same thing as target branch. 
## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
