### PR TITLE
actions/q-146: MOD question EXPLANATIONS r/t github.ref pre and post PR-merge

### DIFF
--- a/questions/en/actions/question-146.md
+++ b/questions/en/actions/question-146.md
@@ -4,8 +4,9 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 ---
 
 - [x] In pull requests that have not been merged, `github.ref` refers to the fully-formed ref of the pull request merge branch/tag 
-> For more information about refs, see the official [Git documentation](https://git-scm.com/book/en/Git-Internals-Git-References).
+> For example, if the (opened) pull request's number was #123, `github.ref` would be `refs/pull/123/merge`. For more information about refs, see the official [Git documentation](https://git-scm.com/book/en/Git-Internals-Git-References).
 - [x] In pull requests that have been merged, `github.ref` refers to the fully-formed ref of the branch that was merged into.
+> For example, if you were merging something into the `main` branch, `github.ref` would be `ref/heads/main` after the pull request was merged.
 - [ ] In pull requests (regardless of merge status), `github.ref` refers to the pull request number 
 > For the `pull_request` event, the value of `github.ref` varies depending on whether the pull request was merged. This value will always be a ref, not the pull request number.
 - [ ] In pull requests (regardless of merge status), `github.ref` is the SHA of the last merge commit on the `GITHUB_REF` branch.


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
In correct answer explanations, adds explicit examples regarding the value of github.ref pre and post PR-merge.:
- For unmerged PRs the example shows `refs/pull/123/merge`
- For merged PRs it shows `ref/heads/main`

### Other Notes

These examples provide an easier understanding of the answer while still keeping the explanations brief. This is especially helpful if you're unfamiliar with how refs are formatted.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
