### PR TITLE
actions/q-161: ADD question r/t OIDC token process

### DIFF
--- a/questions/en/actions/question-161.md
+++ b/questions/en/actions/question-161.md
@@ -1,0 +1,14 @@
+---
+question: "How do workflows integrate with OIDC after a trust relationship has been established?"
+documentation: "https://docs.github.com/en/actions/concepts/security/openid-connect#how-oidc-integrates-with-github-actions"
+---
+
+- [x] A workflow job requests an OIDC token from GitHub's OIDC provider. The OIDC token is then validated by the cloud provider, which then provides a cloud-access token so the workflow can access cloud resources.
+- [ ] A workflow job requests an cloud access token from GitHub's cloud access provider. The token is then validated by the cloud provider, which then provides a OIDC token so the workflow can access cloud resources.
+> OIDC tokens are requested first, then a cloud access token is generated. OIDC tokens cannot access cloud resources.
+- [ ] The `on: OIDC_request` event trigger requests a cloud access token from GitHub's cloud access provider. The token is then validated by the cloud provider, which allows the workflow access to cloud resources.
+> There is no `on: OIDC_request` event trigger.
+- [ ] The `on: OIDC_request` event trigger requests an OIDC token from GitHub's OIDC provider. The token is then validated by the cloud provider, which allows the workflow access to cloud resources.
+> There is no `on: OIDC_request` event trigger.
+- [ ] After adding a workflow to the "OIDC-allowed workflows" list in the repository settings, workflows will automatically create OIDC and cloud access tokens on their own behalf. These tokens can then be used immediately in the workflow to interface with cloud providers
+> There is no "OIDC-allowed workflows" setting.  


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a new questioncovering how GitHub Actions integrates with OIDC and token generation (after a trust relationship is established):
- Clarifies that a workflow job* requests an OIDC token which the cloud provider validates and exchanges for a cloud-access token so the workflow can access cloud resources.
- Clarifies OIDC tokens vs cloud access tokens: Explains that OIDC is more of an intermediate token, rather than providing direct cloud provider access (which is what cloud access tokens do)
- In the question text, notes that a trust relationship must be set up first before token generation can occur. 

### Testing Details

Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes

\* The correct answer says a "workflow job" but really it's a step within that job, not sure if I should be more explicit but these answers are verbose already 
- Speaking of verbosity, I'm aware these answers are long. It's hard to boil down the OIDC process succinctly, which is why the question says "after a trust relationship has been established" as a workaround to making even longer answers. If you have an suggestions to shorten them up while still keeping the concepts covered, let me know

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A