### PR TITLE
actions/q-162: ADD question r/t publshng Docker container actions

### DIFF
--- a/questions/en/actions/question-162.md
+++ b/questions/en/actions/question-162.md
@@ -3,12 +3,12 @@ question: "Mercedes wants to publish a Docker container action she has created t
 documentation: "https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace"
 ---
 
-- [ ] `action.yml`
+- [x] `action.yml`
 > An `action.yml` file is required for an action to be published to the Marketplace, regardless of type.
-- [ ] A `Dockerfile`, if the image is located locally and must be built during the workflow run
-> Docker container actions only require a `Dockerfile` if the image has to be created from scratch and cannot be pulled from an image registry. 
+- [x] A `Dockerfile`, if the image is located locally and must be built during the workflow run
+> Docker container actions only require a `Dockerfile` if the image has to be created from scratch and cannot be pulled from an image registry. The value of `runs.image` in `action.yml` must be the path to `Dockerfile`
 - [ ] A `Dockerfile`, if the image is to be referenced from an image registry
-> When referencing an image in an image registry, no `Dockerfile` is needed. Registry-based images are referenced just like a local `Dockerfile`, via the `runs.image` key in the `action.yml` file.  See the "runs" and "runs.image" sections in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsimage) for more information. 
+> When referencing an image in an image registry, no `Dockerfile` is needed. The value of the `runs.image` key in  `action.yml` must be prefixed with `docker://` followed by the image name.  See the "runs" and "runs.image" sections in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsimage) for more information. 
 - [ ] `README.md`
 > While a `README.md` file is recommended by GitHub for Actions being published to the Marketplace, it is not a strict requirement.
 - [ ] `.dockerignore`

--- a/questions/en/actions/question-162.md
+++ b/questions/en/actions/question-162.md
@@ -1,0 +1,15 @@
+---
+question: "Mercedes wants to publish a Docker container action she has created to the GitHub Actions Marketplace. What files does she need at a minimum to do so?"
+documentation: "https://docs.github.com/en/actions/how-tos/create-and-publish-actions/publish-in-github-marketplace"
+---
+
+- [ ] `action.yml`
+> An `action.yml` file is required for an action to be published to the Marketplace, regardless of type.
+- [ ] A `Dockerfile`, if the image is located locally and must be built during the workflow run
+> Docker container actions only require a `Dockerfile` if the image has to be created from scratch and cannot be pulled from an image registry. 
+- [ ] A `Dockerfile`, if the image is to be referenced from an image registry
+> When referencing an image in an image registry, no `Dockerfile` is needed. Registry-based images are referenced just like a local `Dockerfile`, via the `runs.image` key in the `action.yml` file.  See the "runs" and "runs.image" sections in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsimage) for more information. 
+- [ ] `README.md`
+> While a `README.md` file is recommended by GitHub for Actions being published to the Marketplace, it is not a strict requirement.
+- [ ] `.dockerignore`
+- [ ] `CONTRIBUTING.md`

--- a/questions/en/actions/question-162.md
+++ b/questions/en/actions/question-162.md
@@ -5,7 +5,7 @@ documentation: "https://docs.github.com/en/actions/how-tos/create-and-publish-ac
 
 - [x] `action.yml`
 > An `action.yml` file is required for an action to be published to the Marketplace, regardless of type.
-- [x] A `Dockerfile`, if the image is located locally and must be built during the workflow run
+- [x] A `Dockerfile`, if the image is built as part of the action during the workflow run
 > Docker container actions only require a `Dockerfile` if the image has to be created from scratch and cannot be pulled from an image registry. The value of `runs.image` in `action.yml` must be the path to `Dockerfile`
 - [ ] A `Dockerfile`, if the image is to be referenced from an image registry
 > When referencing an image in an image registry, no `Dockerfile` is needed. The value of the `runs.image` key in  `action.yml` must be prefixed with `docker://` followed by the image name.  See the "runs" and "runs.image" sections in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsimage) for more information. 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Adds a new question that explains the minimum files needed to publish a Docker container action to the GitHub Actions Marketplace:
- Clarifies that action.yml is required,
- Clarifies when a Dockerfile is needed or not (building custom image vs referencing an image registry)
- Clarifies that runs.image is used to reference the Dockerfile/image
- Notes README.md is NOT required, but recommended

### Testing Details
Styling looks good
All links work and lead to proper location

### Other Notes

This combines two different concepts: files needed for publishing an action, and when a Dockerfile is needed. I wanted the runs.image to be mentioned explicitly in the explanations, but can remove that if you think that would help.
Thanks!
## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A