### PR TITLE
actions/q-163: ADD question r/t publishing packages with GitHub Packages

### DIFF
--- a/questions/en/actions/question-163.md
+++ b/questions/en/actions/question-163.md
@@ -6,7 +6,7 @@ documentation: "https://docs.github.com/en/packages/learn-github-packages/publis
 - [x] Logic to publish to GitHub Packages
 > GitHub Packages is a package registry integrated with GitHub, making it easier to use if your needs are GitHub specific (such as with actions/workflows). GitHub Packages includes the ability to host packages privately.
 - [x] A token with `write` permissions 
-> Personal access tokens are supported across all GitHub Packages registries. Certain registries also support the use of `GITHUB_TOKEN`. See the [documentation](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package) for more information.  
+> Personal access tokens are supported across all GitHub Packages registries. Certain registries also support the use of `GITHUB_TOKEN`. See the [documentation](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries) for more information.  
 - [x] Communication logic with the corresponding GitHub Packages registry `https://npm.pkg.github.com`
 > Workflows involved with GitHub Packages often involve communication with the corresponding GitHub-hosted package registry, whose URL has the syntax of `https://<package-type>.pkg.github.com`. For an example, see the [npm registry documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry).
 - [ ] An `on:registry_package` event with no activity types specified

--- a/questions/en/actions/question-163.md
+++ b/questions/en/actions/question-163.md
@@ -1,0 +1,17 @@
+---
+question: "Annette needs to write a workflow to publish a custom `npm` package that only members in her private organization will use. What should her workflow include?"
+documentation: "https://docs.github.com/en/packages/learn-github-packages/publishing-a-package"
+---
+
+- [x] Logic to publish to GitHub Packages
+> GitHub Packages is a package registry integrated with GitHub, making it easier to use if your needs are GitHub specific (such as with actions/workflows). GitHub Packages includes the ability to host packages privately.
+- [x] A token with `write` permissions 
+> Personal access tokens are supported across all GitHub Packages registries. Certain registries also support the use of `GITHUB_TOKEN`. See the [documentation](https://docs.github.com/en/packages/learn-github-packages/publishing-a-package) for more information.  
+- [x] Communication logic with the corresponding GitHub Packages registry `https://npm.pkg.github.com`
+> Workflows involved with GitHub Packages often involve communication with the corresponding GitHub-hosted package registry, whose URL has the syntax of `https://<package-type>.pkg.github.com`. For an example, see the [npm registry documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry).
+- [ ] An `on:registry_package` event with no activity types specified
+> The `on:registry_package` is related to packages, but a workflow does not need this event to publish a package.
+- [ ] A token with `admin` permissions
+> `admin` permissions are only needed when you need to delete a package hosted by GitHub Packages. The principle of least permissions should be followed; in this case, only `write` permissions are needed
+- [ ] An `on:registry_package` event with `types:[published]` 
+> The `on:registry_package` event can be configured to trigger a workflow when a package is published, but a workflow does not need this event to publish a package.

--- a/questions/en/actions/question-163.md
+++ b/questions/en/actions/question-163.md
@@ -5,13 +5,13 @@ documentation: "https://docs.github.com/en/packages/learn-github-packages/publis
 
 - [x] Logic to publish to GitHub Packages
 > GitHub Packages is a package registry integrated with GitHub, making it easier to use if your needs are GitHub specific (such as with actions/workflows). GitHub Packages includes the ability to host packages privately.
-- [x] A token with `write` permissions 
+- [x] A token with `write:packages` permissions 
 > Personal access tokens are supported across all GitHub Packages registries. Certain registries also support the use of `GITHUB_TOKEN`. See the [documentation](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries) for more information.  
 - [x] Communication logic with the corresponding GitHub Packages registry `https://npm.pkg.github.com`
 > Workflows involved with GitHub Packages often involve communication with the corresponding GitHub-hosted package registry, whose URL has the syntax of `https://<package-type>.pkg.github.com`. For an example, see the [npm registry documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry).
 - [ ] An `on:registry_package` event with no activity types specified
 > The `on:registry_package` is related to packages, but a workflow does not need this event to publish a package.
-- [ ] A token with `admin` permissions
-> `admin` permissions are only needed when you need to delete a package hosted by GitHub Packages. The principle of least permissions should be followed; in this case, only `write` permissions are needed
+- [ ] A token with `admin:packages` permissions
+> `admin:packages` permissions are only needed when you need to delete a package hosted by GitHub Packages. The principle of least permissions should be followed; in this case, only `write` permissions are needed
 - [ ] An `on:registry_package` event with `types:[published]` 
 > The `on:registry_package` event can be configured to trigger a workflow when a package is published, but a workflow does not need this event to publish a package.


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a new question describing the required workflow components to publish a custom (npm) package for a private organization using GitHub Packages:
- Explains the use of GitHub Packages in a correct answer's explanation,
- Clarifies a token with write permissions is needed
- Corresponding explanation of "write" permission answer explains this can be a PAT or GITHUB_TOKEN depending on the registry
- Clarifies "admin" permissions are too generous for publishing a package
- Introduces the concept of GitHub Packages registry URLs
- Explains that on:registry_package exists and has activity types, but they are not needed to publish a package

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes
This one's lengthy as it is difficult. I don't think GitHub Packages is covered too much on the exam, but the [study guide](https://assets.ctfassets.net/wfutmusr1t3h/2mMJ6nECbUAdiQMTObbPw6/67cfbffa68fed774a1d280c6c1346635/github-actions-exam-preparation-study-guide__3_.pdf) points out "Demonstrate how to publish to GitHub Packages using a workflow" specifically, so

## Related issue(s)
<!-- If applicable link to related issues -->
N/A

## Screenshots
<!-- (optional) Include related screenshots -->
N/A