### PR TITLE
actions/q-164: ADD question r/t `if` availability

### DIFF
--- a/questions/en/actions/question-164.md
+++ b/questions/en/actions/question-164.md
@@ -1,0 +1,11 @@
+---
+question: "At what levels can `if:` be used in workflows?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax"
+---
+
+- [x] Job-level
+- [x] Step-level
+- [ ] Workflow-level
+> `if:` is not present at workflow-level. To conditionally trigger an entire workflow, other methods must be used such as specifying activity types.
+- [ ] Environment-level
+- [ ] Organization-level


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a new question regarding 'if:' conditionals and the levels they can be applied at:
- Clarifies can be applied at the job and step levels
- Clarifies `if` not available at the workflow (this is the main point of the question--it's important to know this nuance)
- In the explanation for "workflow-level" notes that to conditionally trigger an entire workflow other methods (e.g. specifying activity types) should be used.

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes
I know this one's boring, but knowing that `if:` only works at job and step-level (and NOT at workflow-level) is just one of those things everyone should know when it comes to workflow structure.

Didn't bother adding explanations for environment or organization level since explaining if doesn't apply there might be more trouble than it's worth.

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A