### PR TITLE
actions/q-165: ADD question r/t repository_dispatch flow

### DIFF
--- a/questions/en/actions/question-165.md
+++ b/questions/en/actions/question-165.md
@@ -1,0 +1,15 @@
+---
+question: "How does `respository_dispatch` enable systems outside of GitHub to trigger a workflow?"
+documentation: "https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-dispatch-event"
+---
+
+- [x] The external system makes a POST request to the GitHub API to create a repository dispatch event.
+- [x] The workflow is triggered by the creation of a repository dispatch event 
+> The result of the "Create a repository dispatch event" is a new `repository_dispatch` event (webhook), which `on.repository_dispatch` listens for. 
+- [x] The `on.repository_dispatch.types` workflow key corresponds to the `event_type` parameter in the request payload, restricting the workflow to only trigger on relevant external events 
+> See the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch) for examples of how `on.repository_dispatch.types` and `event_type` relate to each other.
+- [ ] The external system makes a PUT request to the GitHub API to create a repository dispatch event
+> The proper HTTP method for the "Create a repository dispatch event" is POST.
+- [ ] The workflow is triggered by a POST request to the workflow using the following endpoint `/repos/OWNER/REPO/actions/workflows/<WORKFLOW_ID>/dispatches` 
+> This endpoint corresponds to creating a workflow dispatch event, not a repository dispatch event. Furthermore, the GitHub API is what Actions-related requests should be made to--API calls cannot be made the workflow itself.
+- [ ] `repository_dispatch`

--- a/questions/en/actions/question-165.md
+++ b/questions/en/actions/question-165.md
@@ -7,7 +7,7 @@ documentation: "https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-1
 - [x] The workflow is triggered by the creation of a repository dispatch event 
 > The result of the "Create a repository dispatch event" is a new `repository_dispatch` event (webhook), which `on.repository_dispatch` listens for. 
 - [x] The `on.repository_dispatch.types` workflow key corresponds to the `event_type` parameter in the request payload, restricting the workflow to only trigger on relevant external events 
-> `on.repository_dispatch.types` lets you define custom activity types. See the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch) for examples of how `on.repository_dispatch.types` and `event_type` relate to each other.
+> `on.repository_dispatch.types` lets you define custom activity types. See the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch) for examples of how `on.repository_dispatch.types` and `event_type` relate to each other.
 - [ ] The external system makes a PUT request to the GitHub API to create a repository dispatch event
 > The proper HTTP method for the "Create a repository dispatch event" is POST.
 - [ ] The workflow is triggered by a POST request to the workflow using the following endpoint `/repos/OWNER/REPO/actions/workflows/<WORKFLOW_ID>/dispatches` 

--- a/questions/en/actions/question-165.md
+++ b/questions/en/actions/question-165.md
@@ -7,9 +7,10 @@ documentation: "https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-1
 - [x] The workflow is triggered by the creation of a repository dispatch event 
 > The result of the "Create a repository dispatch event" is a new `repository_dispatch` event (webhook), which `on.repository_dispatch` listens for. 
 - [x] The `on.repository_dispatch.types` workflow key corresponds to the `event_type` parameter in the request payload, restricting the workflow to only trigger on relevant external events 
-> See the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch) for examples of how `on.repository_dispatch.types` and `event_type` relate to each other.
+> `on.repository_dispatch.types` lets you define custom activity types. See the [documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch) for examples of how `on.repository_dispatch.types` and `event_type` relate to each other.
 - [ ] The external system makes a PUT request to the GitHub API to create a repository dispatch event
 > The proper HTTP method for the "Create a repository dispatch event" is POST.
 - [ ] The workflow is triggered by a POST request to the workflow using the following endpoint `/repos/OWNER/REPO/actions/workflows/<WORKFLOW_ID>/dispatches` 
 > This endpoint corresponds to creating a workflow dispatch event, not a repository dispatch event. Furthermore, the GitHub API is what Actions-related requests should be made to--API calls cannot be made the workflow itself.
-- [ ] `repository_dispatch`
+- [ ] The `on.repository_dispatch.event_types` workflow key corresponds to the `event_type` parameter in the request payload, restricting the workflow to only trigger on relevant external events
+> There is no `on.repository_dispatch.event_types` key. The `on.repository_dispatch.types` is used, keeping in line with how other events use `on.<event_name>.types` to filter based on activity.

--- a/questions/en/actions/question-165.md
+++ b/questions/en/actions/question-165.md
@@ -1,5 +1,5 @@
 ---
-question: "How does `respository_dispatch` enable systems outside of GitHub to trigger a workflow?"
+question: "How does `repository_dispatch` enable systems outside of GitHub to trigger a workflow?"
 documentation: "https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-dispatch-event"
 ---
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Adds a new question explaining how external systems can trigger workflows via repository_dispatch:
- Clarifies that an external system must POST to the GitHub API to create a repository_dispatch event
- Clarifies that it is the creation of the repository dispatch event/webhook is what causes the workflow to trigger, not an API call directly to the workflow
- Clarifies that on.repository_dispatch.types maps to the event_type payload field,
- One explanation helps differentiate the endpoints for repository_dispatch and workflow_dispatch
- Notes that repository_dispatch allows for custom activity types, and that defining these types uses on.<event_name>.types (reinforces the concept that on.<event_name>.types is a consistent syntax throughout workflows to define activity types

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes
Let me know about the wording. Tried to get all of the main points into one question

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
