### PR TITLE
actions/q-166: ADD question r/t actions/github-script vs JS actions

### DIFF
--- a/questions/en/actions/question-166.md
+++ b/questions/en/actions/question-166.md
@@ -1,0 +1,13 @@
+---
+question: "JavaScript actions and `actions/github-script` both use JavaScript. Why should you use `actions/github-script` versus creating your own JavaScript action?"
+documentation: "https://github.com/actions/github-script"
+---
+
+- [x] `actions/github-script` should be used for short inline scripts
+- [x] `actions/github-script` should be used when you want to use a pre-authenticated client to interact with the GitHub API.
+- [x] JavaScript actions should be used when you want a custom reusable action to be used across repositories 
+- [ ] JavaScript actions should be used for short inline scripts
+- [ ] `actions/github-script` should be used when you need to utilize a fine-tuned Node.js environment with several specific dependencies
+> While you can install modules for `actions/github-script` to use before calling it, if several dependencies are needed, this results in several steps in the workflow. `actions/github-script` also does not allow you to change the Node.js version; you are bound to the one it defines.
+- [ ] JavaScript actions should be used when you want a low-overhead solution to making GitHub API calls.
+> JavaScript actions are not low-overhead; they require making an `action.yml` file, which in turn must be stored in its own folder or even its own repository, depending on the approach. `actions/github-script` comes with a pre-authenticated client that makes it easy to make GitHub API calls using a JavaScript-based approach.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question explaining when to use actions/github-script versus creating a custom JavaScript action: 
 -Clarifies that actions/github-script is suited for short inline scripts and provides a pre-authenticated GitHub API client
- Clarifies JavaScript actions are preferable for reusable custom actions across repositories.
- Notes github-script's limitations with multiple dependencies and fixed Node.js version in an explanation
- Emphasizes that JavaScript actions incur more setup overhead and that actions/github-script should be used as an out-of-the-box solution for simple tasks and GitHub API calls

###Testing Details

Styling looks good
Confirmed all links lead to proper locations

### Other Notes

This question is more oriented towards why you'd actions/github-script, in particular.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
