### PR TITLE
actions/q-169: ADD question r/t self-hosted runners and IP allow lists

### DIFF
--- a/questions/en/actions/question-169.md
+++ b/questions/en/actions/question-169.md
@@ -1,0 +1,11 @@
+---
+question: "Manuela is setting up self-hosted runners for her organization, which has heavily restricted communication with IP addresses. How can she ensure the self-hosted runners can still perform GitHub-related activity?"
+documentation: "https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list"
+---
+
+- [x] Adding the self-hosted runners' IP address(es) to the organization's IP allow list
+> Self-hosted runners communicate with GitHub to perform various activity, as seen in the [documentation](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/runners/self-hosted-runners#communication). To allow this communication, you must add the self-hosted runner's IP address(es) to the IP allow list
+- [ ] Adding the self-hosted runners' operating system to the organization's operating system allow list
+- [ ] Adding the `.ip-exception` file to the top-level of the self-hosted runner's directory structure
+- [ ] Switch to GitHub-hosted standard runners, since self-hosted runners will be blocked if IP allow lists are enabled
+- [ ] Selecting the 'Allow access from self-hosted runners' checkbox in the organization's IP allow list settings

--- a/questions/en/actions/question-169.md
+++ b/questions/en/actions/question-169.md
@@ -1,5 +1,5 @@
 ---
-question: "Manuela is setting up self-hosted runners for her organization, which has heavily restricted communication with IP addresses. How can she ensure the self-hosted runners can still perform GitHub-related activity?"
+question: "Manuela is setting up self-hosted runners for her organization, which has heavily restricted communication with IP addresses. How can she ensure the self-hosted runners can communicate with GitHub?"
 documentation: "https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list"
 ---
 


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

actions/q-169: ADD question r/t self-hosted runners and IP allow lists
Add a new question that asks how to allow self-hosted runners to perform GitHub activity when an organization uses an IP allow list:
- Clarifies adding the self-hosted runner IP address(es) to the organization's IP allow list allows it to communicate with GitHub
- Provides an additional link in regards to what GitHub domains a self-hosted runner may interact with in correct answer explanation for additional context

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes
I intentionally tried not to use "IP allow list" in the question text to not give a hint towards the answer. However I could always rephrase it if needed

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A