### PR TITLE
actions/q-170: ADD question r/t runner labels specification

### DIFF
--- a/questions/en/actions/question-170.md
+++ b/questions/en/actions/question-170.md
@@ -1,0 +1,18 @@
+---
+question: "Observe the values in `runs-on` key as seen in the below workflow job. Which is true regarding how the  the workflow will run?"
+documentation: "https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/use-in-a-workflow#using-custom-labels-to-route-jobs"
+---
+```yaml
+jobs:
+    fire_emblem_deploy:
+        name: "Deploy the 'Fire Emblem' application"
+        runs-on: [self-hosted,nes,linux]
+```
+
+- [x] The workflow will run on a self-hosted runner that has all the labels applied.
+- [ ] The workflow will run on a self-hosted runner that has any of the labels applied.
+> Runner labels apply cumulatively; a workflow will not run on a runner that only has some of the labels. All of them are needed.
+- [ ] The workflow will still be able to run on GitHub-hosted runners, since they can have custom labels applied to them
+> GitHub-hosted runners cannot hvae custom labels applied to them. They must be referenced with the [predefined labels](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories) they have been assigned.
+- [ ] The workflow will run on a runner (self-hosted or GitHub-hosted, whichever is first available) with the name `self-hosted,nes,linux`
+> `runs-on` points to runner labels, not names.

--- a/questions/en/actions/question-170.md
+++ b/questions/en/actions/question-170.md
@@ -13,6 +13,6 @@ jobs:
 - [ ] The workflow will run on a self-hosted runner that has any of the labels applied.
 > Runner labels apply cumulatively; a workflow will not run on a runner that only has some of the labels. All of them are needed.
 - [ ] The workflow will still be able to run on GitHub-hosted runners, since they can have custom labels applied to them
-> GitHub-hosted runners cannot hvae custom labels applied to them. They must be referenced with the [predefined labels](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories) they have been assigned.
+> GitHub-hosted runners cannot have custom labels applied to them. They must be referenced with the [predefined labels](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories) they have been assigned.
 - [ ] The workflow will run on a runner (self-hosted or GitHub-hosted, whichever is first available) with the name `self-hosted,nes,linux`
 > `runs-on` points to runner labels, not names.

--- a/questions/en/actions/question-170.md
+++ b/questions/en/actions/question-170.md
@@ -1,5 +1,5 @@
 ---
-question: "Observe the values in `runs-on` key as seen in the below workflow job. Which is true regarding how the  the workflow will run?"
+question: "Observe the values in `runs-on` key as seen in the below workflow job. Which is true regarding how the  the job will run?"
 documentation: "https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/use-in-a-workflow#using-custom-labels-to-route-jobs"
 ---
 ```yaml
@@ -9,10 +9,10 @@ jobs:
         runs-on: [self-hosted,nes,linux]
 ```
 
-- [x] The workflow will run on a self-hosted runner that has all the labels applied.
-- [ ] The workflow will run on a self-hosted runner that has any of the labels applied.
+- [x] The job will run on a self-hosted runner that has all the labels applied.
+- [ ] The job will run on a self-hosted runner that has any of the labels applied.
 > Runner labels apply cumulatively; a workflow will not run on a runner that only has some of the labels. All of them are needed.
-- [ ] The workflow will still be able to run on GitHub-hosted runners, since they can have custom labels applied to them
+- [ ] The job will still be able to run on GitHub-hosted runners, since they can have custom labels applied to them
 > GitHub-hosted runners cannot have custom labels applied to them. They must be referenced with the [predefined labels](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories) they have been assigned.
-- [ ] The workflow will run on a runner (self-hosted or GitHub-hosted, whichever is first available) with the name `self-hosted,nes,linux`
+- [ ] The job will run on a runner (self-hosted or GitHub-hosted, whichever is first available) with the name `self-hosted,nes,linux`
 > `runs-on` points to runner labels, not names.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question explaining GitHub Actions runs-on label behavior in regards to a workflow running on the runner:
- Clarifies that label matching is cumulative ("AND"-like logic when it comes to labels, not "OR")
- Specifies that "runs-on: [self-hosted, nes, linux]" contains "self-hosted" meaning a self-hosted runner is involved
- Clarifies runs-on uses labels (not runner names)
- Clarifies that GitHub-hosted runners cannot have custom labels, with an explanation link pointing to the predefined labels they use


### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes
This one enforces two major things: 
- Self-hosted runners have custom labels
- If a workflow job runs-on specifies multiple labels the workflow job will only run on a runner that has ALL the labels

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
