### PR TITLE
actions/q-171: ADD question r/t re-run vs new workflow run

### DIFF
--- a/questions/en/actions/question-171.md
+++ b/questions/en/actions/question-171.md
@@ -1,0 +1,14 @@
+---
+question: "Why would you re-run a workflow versus generating a new workflow run?"
+documentation: "https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs"
+---
+
+- [x] Re-running a workflow lets you selectively re-run workflow jobs, as opposed to generating a new run which will run all jobs.
+- [x] Re-running a workflow means the workflow jobs run in the same context of the commit SHA and git ref of the original event that triggered the job
+- [x] Re-running a workflow allows you to enable extra debug logging for the selected job(s).
+- [ ] Re-running a workflow ensures `GITHUB_TRIGGERING_ACTOR` remains unchanged, so it is unambiguous as to who originally triggered the workflow
+> Per the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context), the value of `GITHUB_TRIGGERING_ACTOR` is updated based on who re-ran the workflow.  
+- [ ] Re-running a workflow ensures `GITHUB_ACTOR` is updated, so it is unambiguous as to who re-ran the workflow
+> Per the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context), the value of `GITHUB_ACTOR` is who originally triggered the workflow; it does not change upon re-running a workflow.
+- [ ] Re-running a workflow overwrites the failing job runs, making runs appear more straightforward.
+> Failing job runs remain when a job is re-run. Using the UI, it is easy to toggle between the original job run and subsequent re-runs.  

--- a/questions/en/actions/question-171.md
+++ b/questions/en/actions/question-171.md
@@ -3,7 +3,7 @@ question: "Why would you re-run a workflow versus generating a new workflow run?
 documentation: "https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs"
 ---
 
-- [x] Re-running a workflow lets you selectively re-run workflow jobs, as opposed to generating a new run which will run all jobs.
+- [x] Re-running a workflow lets you re-run failed workflow jobs, as opposed to generating a new run which will run all jobs.
 - [x] Re-running a workflow means the workflow jobs run in the same context of the commit SHA and git ref of the original event that triggered the job
 - [x] Re-running a workflow allows you to enable extra debug logging for the selected job(s).
 - [ ] Re-running a workflow ensures `GITHUB_TRIGGERING_ACTOR` remains unchanged, so it is unambiguous as to who originally triggered the workflow


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question regarding why you might re-run a workflow instead of creating a new run:
- Covers that job re-runs can be selective
- Clarifies the re-runs preserve the original commit SHA/ref
- Clarifies re-runs enable extra debug logging
- Clarifies context variable behavior (GITHUB_TRIGGERING_ACTOR is updated when re-run, while GITHUB_ACTOR remains the original trigger).
- Notes that failing job runs are preserved and can be viewed alongside re-runs.

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

## Related issue(s)
<!-- If applicable link to related issues -->
N/A

## Screenshots
<!-- (optional) Include related screenshots -->
N/A