### PR TITLE
actions/q-172: ADD question r/t runner groups

### DIFF
--- a/questions/en/actions/question-172.md
+++ b/questions/en/actions/question-172.md
@@ -1,0 +1,10 @@
+---
+question: "Ingrid's organization has a subset of self-hosted Linux runners that should only be used by certain repositories. What is the best approach for Ingrid to enforce this behavior?"
+documentation: ""
+---
+
+- [x] Create a new runner group, add the runners to the group, then select which repositories are allowed access to the group in the group settings.
+- [ ] Create a new runner label, add the labels to the runners, then select which repositories are allowed access to the label in the label settings.
+- [ ] Create a new runner label, add the labels to the runners, then make sure all workflows in the repositories have that label included in their `runs-on` field.
+> Labels do not limit access to runners. Simply adding a label will not work; adding labels to `runs-on` can potentially effect the corresponding workflow from finding a runner to run on.
+- [ ] Create a new runner group, select "Linux" as the OS, and use glob patterns to define which repositories are allowed access in the group settings.  

--- a/questions/en/actions/question-172.md
+++ b/questions/en/actions/question-172.md
@@ -1,5 +1,5 @@
 ---
-question: "Ingrid's organization has a subset of self-hosted Linux runners that should only be used by certain repositories. What is the best approach for Ingrid to enforce this behavior?"
+question: "Ingrid's organization has a subset of self-hosted Linux runners that should only be used by certain repositories. What is the best approach for her to enforce this behavior?"
 documentation: ""
 ---
 

--- a/questions/en/actions/question-172.md
+++ b/questions/en/actions/question-172.md
@@ -1,6 +1,6 @@
 ---
 question: "Ingrid's organization has a subset of self-hosted Linux runners that should only be used by certain repositories. What is the best approach for her to enforce this behavior?"
-documentation: ""
+documentation: "https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/manage-access#changing-which-repositories-can-access-a-runner-group"
 ---
 
 - [x] Create a new runner group, add the runners to the group, then select which repositories are allowed access to the group in the group settings.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question about limiting repository to access self-hosted runners via runner groups:
- Clarifies that the correct approach is to create a runner group and allow selected repositories,
- Notes that labels do not restrict runner access.
- Notes that adding labels to runs-on can effect workflows from being picked up by runners

###Testing Details
Styling looks good
All links work and lead to proper locations

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
