### PR TITLE
actions/q-134: MOD r/t stylizing explanation's star character * 

### DIFF
--- a/questions/en/actions/question-134.md
+++ b/questions/en/actions/question-134.md
@@ -12,4 +12,4 @@ documentation: "https://github.com/marketplace/actions/github-script"
 - [ ] Write the contents of a script block to the `GITHUB_SCRIPT` environmental variable
 > `GITHUB_SCRIPT` is not a default Github Actions environmental variable. A list of default environmental variables can be found in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/variables)
 - [ ] In a JavaScript Action, set the `using` key to `'github-script'`
-> JavaScript Actions must have their `using` key set to `node*` where * is a supported version of Node.js.  Generally, JavaScript Actions do not have a need for `actions/github-script`.
+> JavaScript Actions must have their `using` key set to `node*` where `*` is a supported version of Node.js.  Generally, JavaScript Actions do not have a need for `actions/github-script`.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Modifies the star `*` character in an explanation to be stylized in `inline style` for conformity.

### Testing Details
Styling looks good

### Other Notes
I know it's like the dumbest commit ever but consistency and attention to detail are important!

## Related issue(s)
<!-- If applicable link to related issues -->
N/A
## Screenshots
<!-- (optional) Include related screenshots -->
N/A