### PR TITLE
actions/q-173: ADD r/t self-hosted runners (applied example)

### DIFF
--- a/questions/en/actions/question-173.md
+++ b/questions/en/actions/question-173.md
@@ -7,7 +7,7 @@ documentation: "https://docs.github.com/en/actions/concepts/runners/self-hosted-
 - [ ] One self-hosted runner per repository, set up at the repository level
 > This would be duplicative and complex to manage. Repositories can reference the same organization-level runner, which is the correct approach in this situation.
 - [ ] GitHub-hosted runners, with all workflows utilizing `actions/setup-node`
-> GitHub-hosted runners are [ephermal](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#overview-of-github-hosted-runners), meaning that a new instance of the runner is set up per workflow run. This would not work well with node-locking software, which only allows the software to run on a specified device/VM. Additionally, while GitHub-hosted runners can be set up to access private networks, this is not out-of-the-box functionality.
+> GitHub-hosted runners are [ephemeral](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#overview-of-github-hosted-runners), meaning that a new instance of the runner is set up per workflow run. This would not work well with node-locking software, which only allows the software to run on a specified device/VM. Additionally, while GitHub-hosted runners can be set up to access private networks, this is not out-of-the-box functionality.
 - [ ] GitHub-hosted runners set up at the organization-level
 > GitHub-hosted runners cannot be set up in this way.
 - [ ] GitHub-hosted runners, using `runs-on: [node<version>]` (`<version>` being the desired Node version) in all workflows.

--- a/questions/en/actions/question-173.md
+++ b/questions/en/actions/question-173.md
@@ -1,0 +1,14 @@
+---
+question: "An organization has several repositories that share a specialized Node.js environment hosted on a private network. The organization's next objective involves the setup of node-locking software within that network. Which of the following would best suit the organization's needs when it comes to executing workflows?"
+documentation: "https://docs.github.com/en/actions/concepts/runners/self-hosted-runners"
+---
+
+- [x] Self-hosted runners set up at the organization-level
+- [ ] One self-hosted runner per repository, set up at the repository level
+> This would be duplicative and complex to manage. Repositories can reference the same organization-level runner, which is the correct approach in this situation.
+- [ ] GitHub-hosted runners, with all workflows utilizing `actions/setup-node`
+> GitHub-hosted runners are [ephermal](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#overview-of-github-hosted-runners), meaning that a new instance of the runner is set up per workflow run. This would not work well with node-locking software, which only allows the software to run on a specified device/VM. Additionally, while GitHub-hosted runners can be set up to access private networks, this is not out-of-the-box functionality.
+- [ ] GitHub-hosted runners set up at the organization-level
+> GitHub-hosted runners cannot be set up in this way.
+- [ ] GitHub-hosted runners, using `runs-on: [node<version>]` (`<version>` being the desired Node version) in all workflows.
+> `[node<version>]` does not point to any GitHub-hosted runner.


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a question r/t an applied use case of when to use a self-hosted runner:
- Scenario: specialized Node.js environment on a private network, with node-locking software to come
- Notes self-hosted runners can be set organization-level and used by multiple repositories
- Explains why per-repo self-hosted runners is an unorganized approach
- Explains that GitHub-hosted runners are ephermal, which won't work with node-locking software
- Explains that GitHub-hosted runners can access private networks, this is not default behavior.

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes

I hope this is accurate as a real-life example. I think it's important to have scenario-based questions like this to really see if people get why you'd use a self-hosted runner and the level you'd use it at. I'm sure the wording could be improved in some areas but I would like the core of the question to keep its specificity, as those details help confirm why a self-hosted runner at org level is the correct answer

## Related issue(s)
<!-- If applicable link to related issues -->
N/A

## Screenshots
<!-- (optional) Include related screenshots -->
N/A