### PR TITLE
actions/q-174: ADD question r/t permissions and reusable workflows

### DIFF
--- a/questions/en/actions/question-174.md
+++ b/questions/en/actions/question-174.md
@@ -1,0 +1,45 @@
+---
+question: "The following workflow that calls a reusable workflows in one of its jobs. The reusable workflow has `permissions` defined at workflow level as seen below. What will be the result of calling the reusable workflow?"
+documentation: "https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows"
+---
+
+```yaml
+# caller workflow
+on:
+    issues:
+        types: [opened]
+    
+    permissions:
+        contents: write
+
+    jobs:
+        issue_creator:
+            runs-on: ubuntu-latest
+            permissions:
+                contents: read
+            uses: ./.github/workflows/issue-creator.yml
+
+# reusable workflow (issue-creator.yml)
+on:
+    workflow_call:
+
+    permissions:
+        contents: write
+
+    jobs:
+        create_issue:
+            runs-on: ubuntu-latest
+            steps: 
+                env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+                -run: gh issue create --title "Issue report" --body "Hello!" --repo $GITHUB_REPOSITORY
+
+```
+- [x] The reusable workflow will return an error, since the job that called it only has `contents:read` permissions
+> NEED TO TEST THIS
+- [ ] The reusable workflow will create an issue in the caller workflow's repository titled `"Issue Report"`
+> This would occur if the `issue_creator` job had `contents:write` permissions, which would be the reusable workflow would inherit
+- [ ] The reusable workflow will create an issue in its own repository titled `"Issue Report"`
+- [ ] The reusable workflow will not be called, since reusable workflows must be in a subfolder of `.github/workflows`
+> All workflows must be located in the `.github/workflows` directory. 
+- [ ] Both the caller and reusable workflow will not get called, because `issues` is not an available trigger for GitHub Actions. 
+> `issues` is a standard event trigger, as seen in the documentation TODO DOCS!

--- a/questions/en/actions/question-174.md
+++ b/questions/en/actions/question-174.md
@@ -14,7 +14,6 @@ on:
 
     jobs:
         issue_creator:
-            runs-on: ubuntu-latest
             permissions:
                 contents: read
             uses: ./.github/workflows/issue-creator.yml
@@ -31,15 +30,14 @@ on:
             runs-on: ubuntu-latest
             steps: 
                 env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
-                -run: gh issue create --title "Issue report" --body "Hello!" --repo $GITHUB_REPOSITORY
+                - run: gh issue create --title "Issue report" --body "Hello!" --repo $GITHUB_REPOSITORY
 
 ```
 - [x] The reusable workflow will return an error, since the job that called it only has `contents:read` permissions
-> NEED TO TEST THIS
-- [ ] The reusable workflow will create an issue in the caller workflow's repository titled `"Issue Report"`
+> In this scenario the caller workflow is triggered, but its job will not fire. Instead an error will be generated saying the caller workflow file is not valid since the reusable workflow is requesting `contents: write`, but is only allowed `contents: read`.
+- [ ] The reusable workflow will create an issue in the repository titled `"Issue Report"`
 > This would occur if the `issue_creator` job had `contents:write` permissions, which would be the reusable workflow would inherit
-- [ ] The reusable workflow will create an issue in its own repository titled `"Issue Report"`
 - [ ] The reusable workflow will not be called, since reusable workflows must be in a subfolder of `.github/workflows`
 > All workflows must be located in the `.github/workflows` directory. 
 - [ ] Both the caller and reusable workflow will not get called, because `issues` is not an available trigger for GitHub Actions. 
-> `issues` is a standard event trigger, as seen in the documentation TODO DOCS!
+> `issues` is a standard event trigger, as seen in the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issues)


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Add a new question about permission inheritance for reusable workflows:
- The file includes a scenario with caller and reusable workflows and how permissions work when a reusable workflow is called when it has its own `permissions` block whose contents are elevated compared to the job's `permissions` block
- Shows an example of using GitHub CLI
- Clarifies that the reusable workflow inherits the caller's permissions (contents: read), even if the reusable workflow has a workflow-level set of permissions defined.

### Testing Details
Styling looks good
All links work and lead to proper locations

### Other Notes

This is a good idea, but I definitely need input on refining it. Maybe it's too niche?
Basically the objectives of this question are thus:
- Reusable workflows inherit the permissions of their calling job, even if the reusable workflow has its own permissions block (at workflow level)
- If possible, keep the YAML example as is to keep this question scenario-based

I was able to test this in a repo. The error specifically returned is 
`The workflow is not valid. .github/workflows/caller-permission-test.yml (Line: 17, Col: 5): Error calling workflow 'org-mushroom-kingdom/ttn-workflows/.github/workflows/reusable-workflow-test.yml@a4785784ec74a74ae04ef356b1e14e55f5b57bb7'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.`

If this is too niche, I can edit it so that the reusable workflow doesn't have a permissions block, but still tries to create an issue, which results in a different error `GraphQL: Resource not accessible by integration (createIssue)`. 

Edit or not, an error is still made due to conflicting/elevated permissions in the reusable workflow, it's just the pathology of that error.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
