### PR TITLE
actions/q-175: ADD question r/t not using actions/checkout when referencing repo files

### DIFF
--- a/questions/en/actions/question-175.md
+++ b/questions/en/actions/question-175.md
@@ -1,0 +1,31 @@
+---
+question: "Catherine writes the following workflow job below. What will be the result of the job?"
+documentation: "https://github.com/actions/checkout"
+---
+
+```yaml
+jobs:
+  doc-generate:
+    name: "Generate Scaffold Doc"
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Setup Python 3.13 
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+
+      - name: Grant Execute Permission to Scaffolding Python Script
+        run: chmod +x ./scripts/scaffold-doc.py
+
+      - name: Execute Scaffolding Python Script
+        run: python ./scripts/scaffold-doc.py
+```
+
+- [x] The Python script will not run, because `actions/checkout` is not included in the workflow.
+> `actions/checkout` is necessary to check out the repository's code into the runner's file system. If it is not used, the Python script will not be found and thus not executed.
+- [ ] The Python script will run successfully, because the `chmod` command grants execute permissions to the script.
+> This would be true if `actions/checkout` was used.
+- [ ] The Python script will not run, because `runs-on` does not have a value of `python`.
+- [ ] The Python script will not run, because `actions/python-setup` is not the correct action for setting up Python.
+> Most official actions that set up programming languages use the structure `actions/setup-<language>`. 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->


Add a new question r/t a GitHub Actions workflow that omits actions/checkout and tries to reference a repo file:
- Explains that the Python script will not run (because it can't be found) because actions/checkout is required to populate the workspace.
- Clarifies that in general `actions/setup-<language>` is the common syntax for setting up programming languages in a runner

### Testing Details
Styling looks good
Confirmed all links work and lead to proper locations

### Other Notes
There's no docs that really say what happens if actions/checkout isn't used and then you try to reference a repository file. This can be easily tested and confirmed, however.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
