### PR TITLE
actions/q-176: ADD question r/t multiple events and `schedule` (applied example)

### DIFF
--- a/questions/en/actions/question-176.md
+++ b/questions/en/actions/question-176.md
@@ -1,5 +1,5 @@
 ---
-question: "Leonie has a workflow that should be triggered time a commit is made to the repository. The repository is not always that active, so Leonie desires the workflow to programmatically run once a week as a failsafe. What combination of events should she use to enforce this behavior?"
+question: "Judith has a workflow that should be triggered time a commit is made to the repository. The repository is not always that active, so Judith desires the workflow to programmatically run once a week as a failsafe. What combination of events should she use to enforce this behavior?"
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows"
 ---
 

--- a/questions/en/actions/question-176.md
+++ b/questions/en/actions/question-176.md
@@ -1,5 +1,5 @@
 ---
-question: "Judith has a workflow that should be triggered time a commit is made to the repository. The repository is not always that active, so Judith desires the workflow to programmatically run once a week as a failsafe. What combination of events should she use to enforce this behavior?"
+question: "Judith has a workflow that should be triggered every time a commit is made to the repository. The repository is not always that active, so Judith desires the workflow to programmatically run once a week as a failsafe. What combination of events should she use to enforce this behavior?"
 documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows"
 ---
 

--- a/questions/en/actions/question-176.md
+++ b/questions/en/actions/question-176.md
@@ -4,10 +4,10 @@ documentation: "https://docs.github.com/en/actions/reference/workflows-and-actio
 ---
 
 - [x] `push` and `schedule`
-- [] `pull_request` (with `types:[closed]`) and `schedule`
+- [ ] `pull_request` (with `types:[closed]`) and `schedule`
 > Pull requests can closed without being merged, and commits can be made to a repository without a pull request.
-- [] `push` and `workflow_dispatch`
+- [ ] `push` and `workflow_dispatch`
 > The word "programmatically" in the question means that the workflow should be triggered in a non-manual way. Having users manually have to trigger a workflow every week is not reliable--it can and should be automated via `schedule` 
-- [] `push` and `weekly`
-> `weekly` is not a valid event. Use `schedule` with cron syntax to set the workflow to run weekly.
-- [] `pull_request` (with `types:[closed]`) and `weekly`
+- [ ] `push` and `weekly`
+> `weekly` is not a valid event. Use `schedule` with `cron` syntax to set the workflow to run weekly.
+- [ ] This is not possible: `schedule` cannot be combined with other events

--- a/questions/en/actions/question-176.md
+++ b/questions/en/actions/question-176.md
@@ -1,0 +1,13 @@
+---
+question: "Leonie has a workflow that should be triggered time a commit is made to the repository. The repository is not always that active, so Leonie desires the workflow to programmatically run once a week as a failsafe. What combination of events should she use to enforce this behavior?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows"
+---
+
+- [x] `push` and `schedule`
+- [] `pull_request` (with `types:[closed]`) and `schedule`
+> Pull requests can closed without being merged, and commits can be made to a repository without a pull request.
+- [] `push` and `workflow_dispatch`
+> The word "programmatically" in the question means that the workflow should be triggered in a non-manual way. Having users manually have to trigger a workflow every week is not reliable--it can and should be automated via `schedule` 
+- [] `push` and `weekly`
+> `weekly` is not a valid event. Use `schedule` with cron syntax to set the workflow to run weekly.
+- [] `pull_request` (with `types:[closed]`) and `weekly`


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->


Add a new question r/t which events should trigger a workflow to run on commits and also run programmatically once a week, in an applied example format.:
- Reinforces the fact workflows can have multiple event triggers
- Specifies that `pull_request` `types:[closed]` is not synonymous with a `push` event
- Specifies that `workflow_dispatch` is inappropriate in this case, since programmatic behavior was specified
- One explanation notes that cron syntax should be used along with schedule

### Testing Details
Styling OK
Links work and lead to proper locations

### Other Notes
One of the GitHub study guide items is "Configure workflows to run for one or more events" and keeping in with the spirit of more scenario-based questions, here we are.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
