### PR TITLE
actions/q-177: ADD question r/t schedule and cron syntax

### DIFF
--- a/questions/en/actions/question-177.md
+++ b/questions/en/actions/question-177.md
@@ -1,0 +1,42 @@
+---
+question: "Your workflow must fire off at 12:00 AM every Monday and Friday. Which of the following snippets correlates to this behavior?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule"
+---
+
+- [x] 
+```yaml
+on:
+  schedule:
+    - cron: '0 0 * * 1,5'
+```
+> `cron` syntax has its items defined in order of increasing magnitude, with the exception that the "day(s) of the week" item being the last item. See the [documentation](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07) for more information and examples.
+
+- [ ] 
+```yaml
+on:
+  schedule:
+    - cron: '0 12 * * Mon,Fri'
+```
+> The "day(s) of the week" item must be in numerical format. Additionally, the "minute" and "hour" items point to 12:00 PM, not 12:00 AM.
+
+- [ ] 
+```yaml
+on:
+  workflow_schedule:
+    - cron: '0 0 * * 1,5'
+```
+
+- [ ] 
+```yaml
+on:
+  workflow_schedule:
+    - cron: '1,5 * * 0 0'
+```
+
+- [ ] 
+```yaml
+on:
+  workflow_call:
+    - days: [Mon,Fri]
+    - times: [00]
+```


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question file r/t using `schedule` and `cron` syntax appropriately:
- Specifies that `schedule` is the correct event
- Gives various examples of `cron` syntax, with elaboration in some explanations (as well as a link to `cron` documentation)

### Testing Details
Styling OK
Links work and lead to proper locations

### Other Notes
More to reinforce that `schedule` is the correct event, and to test user's `cron` syntax knowledge


## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
