### PR TITLE
actions/q-175: MOD question r/t phrasing of incorrect "actions/python-setup" answer

### DIFF
--- a/questions/en/actions/question-175.md
+++ b/questions/en/actions/question-175.md
@@ -27,5 +27,5 @@ jobs:
 - [ ] The Python script will run successfully, because the `chmod` command grants execute permissions to the script.
 > This would be true if `actions/checkout` was used.
 - [ ] The Python script will not run, because `runs-on` does not have a value of `python`.
-- [ ] The Python script will not run, because `actions/python-setup` is not the correct action for setting up Python.
+- [ ] The Python script will not run, because `actions/python-setup` is the correct action for setting up Python.
 > Most official actions that set up programming languages use the structure `actions/setup-<language>`. 


### PR DESCRIPTION

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Fixes the incorrect answer to say "_...'actions/python-setup' is the correct action_". The "not" in here previously would've made this answer semi-correct, since "actions/python-setup" isn't a real action (even if the correct one is referenced in the question). Basically, this makes the incorrect answer "more incorrect"

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
