### PR TITLE
actions/q-056: MOD question r/t documentation link (deployment rules)

### DIFF
--- a/questions/en/actions/question-056.md
+++ b/questions/en/actions/question-056.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you require manual approvals by a maintainer if the workflow run is targeting the `production` environment?"
-documentation: "https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments#deployment-protection-rules"
 ---
 
 - [x] Using deployment protection rules


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->
Modifies the documentation link regarding deployment protection rules:
- The current link doesn't mention manual approvals. The new link does.

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
