### PR TITLE
actions/q-178: ADD question r/t required reviewers for deployment protection rules

### DIFF
--- a/questions/en/actions/question-178.md
+++ b/questions/en/actions/question-178.md
@@ -1,0 +1,14 @@
+---
+question: "You need to ensure that your `prod` environment requires manual approvals before deploys can proceed. Out of the following options, which are true regarding how this is set up?"
+documentation: "https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments#required-reviewers"
+---
+
+- [x] If you list required reviewers, only one of them needs to approve to continue with the deployment.
+- [x] You can prevent self-reviews in the event the person who wants to deploy is also a required reviewer.
+- [ ] If you list required reviewers, all of them need to approve to continue with the deployment.
+> Surprisingly only 1 of the required reviewers needs to approve the workflow job. To enforce this behavior, you would need to create a custom deployment protection rule via a GitHub App.
+- [ ] You cannot prevent self-reviews, but you can set up alerts to see who triggered the deployment.
+- [ ] Only individual users can be assigned as required reviewers, not teams.
+> Both individual users and teams can be assigned as required reviewers
+- [ ] Required reviewers need at least `write` access to the repository in order to approve.
+> Required reviewers need at least `read` access


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
<!-- Describe what this PR changes -->

Add a new question r/t require manual approvals (required reviewers) for deployment protection rules:
- Notes that listing required reviewers only requires one approval
- Clarifies self-reviews can be prevented
- Clarifies both individual users and teams can be reviewers
- Clarifies required reviewers need at least read access.

### Testing Details
Styling OK
Links work and lead to proper locations

## Related issue(s)
<!-- If applicable link to related issues -->

## Screenshots
<!-- (optional) Include related screenshots -->
