### PR TITLE
chore: add lint and type check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,17 @@ repos:
     hooks:
       - id: check-yaml
       - id: check-toml
+  - repo: local
+    hooks:
+      - id: lint
+        name: lint
+        entry: bash -c "cd app && npm run lint"
+        language: system
+        types: [javascript, typescript, jsx, tsx]
+        pass_filenames: false
+      - id: tsc
+        name: tsc
+        entry: bash -c "cd app && npx tsc --noEmit"
+        language: system
+        types: [typescript, tsx]
+        pass_filenames: false


### PR DESCRIPTION
Add eslint and TypeScript type checking to pre-commit hooks to ensure code quality and prevent regressions by automatically validating code before commits.