### PR TITLE
ci: improve link-checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch: 
   schedule:
     - cron: "0 6 * * *"
+      timezone: "Europe/Warsaw"
+  pull_request:
+    paths:
+      - .github/workflows/link-checker.yml
 
 permissions:
   contents: read
@@ -13,6 +17,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         exam: [actions, admin, advanced_security, agentic, copilot, foundations]
     steps:
@@ -21,11 +26,13 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
+          fail: false
           args: --verbose --no-progress './**/*.md' --exclude-all-private --exclude 'file:///*'
           workingDirectory: questions/en/${{ matrix.exam }}
+          
 
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: "Link Checker Report: ${{ matrix.exam }}"


### PR DESCRIPTION
- don't fail job on lychee errors, let issue creation step run
- disable fail-fast so all matrix exams complete
- trigger on PRs editing this workflow file
- add Europe/Warsaw timezone to schedule
- skip issue creation on pull_request trigger
