### PR TITLE
ci: use Copilot CLI to auto-fix broken/redirected links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,16 +10,17 @@ on:
       - .github/workflows/link-checker.yml
 
 permissions:
-  contents: read
-  issues: write
+  contents: write
+  pull-requests: write
+  copilot-requests: write
+
+env:
+  LYCHEE_REPORT_PATH: lychee/out.md
+  COPILOT_SUMMARY_PATH: summary.md
 
 jobs:
   check-links:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        exam: [actions, admin, advanced_security, agentic, copilot, foundations]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Link Checker
@@ -27,14 +28,34 @@ jobs:
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           fail: false
-          args: --verbose --no-progress './**/*.md' --exclude-all-private --exclude 'file:///*'
-          workingDirectory: questions/en/${{ matrix.exam }}
-          
+          output: ${{ env.LYCHEE_REPORT_PATH }}
+          args: --verbose --no-progress 'questions/en/**/*.md' --exclude-all-private --exclude 'file:///*'
 
-      - name: Create Issue From File
+      - name: Install Copilot CLI
         if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        run: npm install -g @github/copilot
+
+      - name: Fix links with Copilot
+        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          copilot -p "Read the lychee link-checker report at ${{ env.LYCHEE_REPORT_PATH }}.
+          Only edit files under questions/en/ (never other questions/<lang>/ dirs).
+          For each redirected link, replace it with its final resolved URL.
+          For each broken (4xx/5xx) link, replace it with an obviously correct replacement
+          only if confident, otherwise leave it unchanged and list it as unresolved.
+          Don't change anything else in the files.
+          When done, write a short Markdown summary with '## Fixed' and '## Unresolved'
+          sections listing the affected file and URL for each link to ${{ env.COPILOT_SUMMARY_PATH }}" \
+            --allow-tool=write --no-ask-user
+
+      - name: Open PR with fixes
+        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
-          title: "Link Checker Report: ${{ matrix.exam }}"
-          content-filepath: questions/en/${{ matrix.exam }}/lychee/out.md
+          add-paths: questions/en/**
+          branch: fix/link-checker
+          title: "fix: broken/redirected links found by link checker"
+          body-path: ${{ env.COPILOT_SUMMARY_PATH }}
           labels: good first issue, bug

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,6 +22,10 @@ env:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        exam: [actions, admin, advanced_security, agentic, copilot, foundations]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Link Checker
@@ -30,7 +34,8 @@ jobs:
         with:
           fail: false
           output: ${{ env.LYCHEE_REPORT_PATH }}
-          args: --verbose --no-progress 'questions/en/**/*.md' --exclude-all-private --exclude 'file:///*'
+          args: --verbose --no-progress './**/*.md' --exclude-all-private --exclude 'file:///*'
+          workingDirectory: questions/en/${{ matrix.exam }}
 
       - name: Install Copilot CLI
         if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
@@ -41,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          copilot -p "Read the lychee link-checker report at ${{ env.LYCHEE_REPORT_PATH }}.
-          Only edit files under questions/en/ (never other questions/<lang>/ dirs).
+          copilot -p "Read the lychee link-checker report at questions/en/${{ matrix.exam }}/${{ env.LYCHEE_REPORT_PATH }}.
+          Only edit files under questions/en/${{ matrix.exam }}/ (never other exam or language dirs).
 
           For each REDIRECTED link, replace it with the final resolved URL already shown
           in the report.
@@ -70,6 +75,6 @@ jobs:
         uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
           add-paths: questions/en/**
-          branch: fix/link-checker
-          title: "fix: broken/redirected links found by link checker"
+          branch: fix/link-checker-${{ matrix.exam }}
+          title: "fix: broken/redirected links in ${{ matrix.exam }}"
           body-path: ${{ env.COPILOT_SUMMARY_PATH }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,7 +3,7 @@ name: Links
 on:
   workflow_dispatch: 
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 1 * *"
       timezone: "Europe/Warsaw"
   pull_request:
     paths:
@@ -38,11 +38,11 @@ jobs:
           workingDirectory: questions/en/${{ matrix.exam }}
 
       - name: Install Copilot CLI
-        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: npm install -g @github/copilot
 
       - name: Fix links with Copilot
-        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -71,10 +71,10 @@ jobs:
             --allow-tool=shell --allow-tool=write --allow-tool=context7 --allow-all-urls --no-ask-user --max-ai-credits=${{ env.COPILOT_MAX_AI_CREDITS }}
 
       - name: Open PR with fixes
-        if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
-          add-paths: questions/en/**
+          add-paths: questions/en/${{ matrix.exam }}/**
           branch: fix/link-checker-${{ matrix.exam }}
           title: "fix: broken/redirected links in ${{ matrix.exam }}"
           body-path: ${{ env.COPILOT_SUMMARY_PATH }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -78,3 +78,5 @@ jobs:
           branch: fix/link-checker-${{ matrix.exam }}
           title: "fix: broken/redirected links in ${{ matrix.exam }}"
           body-path: ${{ env.COPILOT_SUMMARY_PATH }}
+          labels: link-checker
+          

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -17,6 +17,7 @@ permissions:
 env:
   LYCHEE_REPORT_PATH: lychee/out.md
   COPILOT_SUMMARY_PATH: summary.md
+  COPILOT_MAX_AI_CREDITS: 100
 
 jobs:
   check-links:
@@ -42,13 +43,27 @@ jobs:
         run: |
           copilot -p "Read the lychee link-checker report at ${{ env.LYCHEE_REPORT_PATH }}.
           Only edit files under questions/en/ (never other questions/<lang>/ dirs).
-          For each redirected link, replace it with its final resolved URL.
-          For each broken (4xx/5xx) link, replace it with an obviously correct replacement
-          only if confident, otherwise leave it unchanged and list it as unresolved.
+
+          For each REDIRECTED link, replace it with the final resolved URL already shown
+          in the report.
+
+          For each BROKEN (4xx/5xx) link, try to find the correct replacement before giving up:
+          - Use the context7 MCP tools to look up the relevant library/product docs and find
+            the page that replaced it.
+          - Or fetch the linked domain's search/nearby pages to locate the moved content.
+          - Verify the replacement URL actually resolves (200 OK) before using it.
+          Only replace the link if you're confident the replacement covers the same content.
+          Otherwise leave it unchanged and list it as unresolved.
+
           Don't change anything else in the files.
-          When done, write a short Markdown summary with '## Fixed' and '## Unresolved'
-          sections listing the affected file and URL for each link to ${{ env.COPILOT_SUMMARY_PATH }}" \
-            --allow-tool=write --no-ask-user
+          When done, write the summary to ${{ env.COPILOT_SUMMARY_PATH }} as a single
+          Markdown table with columns: File | Old URL | New URL / Reason | Status.
+          - File: path relative to repo root
+          - Old URL: the link as reported by lychee
+          - New URL / Reason: the replacement URL if Fixed, or a short reason if Unresolved
+          - Status: 'Fixed' or 'Unresolved'
+          One row per link. No extra commentary before or after the table." \
+            --allow-tool=shell --allow-tool=write --allow-tool=context7 --allow-all-urls --no-ask-user --max-ai-credits=${{ env.COPILOT_MAX_AI_CREDITS }}
 
       - name: Open PR with fixes
         if: steps.lychee.outputs.exit_code != 0 && github.event_name != 'pull_request'
@@ -58,4 +73,3 @@ jobs:
           branch: fix/link-checker
           title: "fix: broken/redirected links found by link checker"
           body-path: ${{ env.COPILOT_SUMMARY_PATH }}
-          labels: good first issue, bug

--- a/questions/en/admin/question-002.md
+++ b/questions/en/admin/question-002.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the GitHub Dependabot dependency graph?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph"
 ---
 
 - [x] It is a representation of a repository's dependencies and dependents.

--- a/questions/en/advanced_security/question-009.md
+++ b/questions/en/advanced_security/question-009.md
@@ -1,6 +1,6 @@
 ---
 question: "What's the purpose of the Secret scanning partner program?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program"
+documentation: "https://docs.github.com/en/code-security/tutorials/secret-scanning-partner-program"
 ---
 
 - [x] Service Providers can partner with GitHub so that the format of their secrets can be recognized by GitHub secret scanning.

--- a/questions/en/advanced_security/question-010.md
+++ b/questions/en/advanced_security/question-010.md
@@ -1,6 +1,6 @@
 ---
 question: "Public repositories owned by personal users as well as public repositories owned by organizations can use secret scanning for free."
-documentation: "https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#about-secret-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning#about-secret-scanning"
 ---
 
 - [x] True

--- a/questions/en/advanced_security/question-011.md
+++ b/questions/en/advanced_security/question-011.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you prevent commits containing cloud provider credentials from being pushed to GitHub?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations"
+documentation: "https://docs.github.com/en/code-security/concepts/secret-security/push-protection"
 ---
 
 - [x] Enable a secret scanning push protection rule for your repository or organization.

--- a/questions/en/advanced_security/question-012.md
+++ b/questions/en/advanced_security/question-012.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these is true about the GitHub secret scanning partner program?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program"
+documentation: "https://docs.github.com/en/code-security/tutorials/secret-scanning-partner-program"
 ---
 
 - [x] It is a program where service providers can provide GitHub with the regex patterns of secrets that they issue so GitHub secret scanning can recognize them.

--- a/questions/en/advanced_security/question-013.md
+++ b/questions/en/advanced_security/question-013.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you exclude certain directories or files from secret scanning?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/configuring-secret-scanning-for-your-repositories#excluding-directories-from-secret-scanning-alerts-for-users"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files"
 ---
 
 - [x] By creating a `secret_scanning.yml` file and including paths that should not be scanned

--- a/questions/en/advanced_security/question-014.md
+++ b/questions/en/advanced_security/question-014.md
@@ -1,6 +1,6 @@
 ---
 question: "You have included some fake secrets in your test code and they have been picked up by GitHub's secret scanning. What can you do to tell GitHub that these are fake secrets used in tests and can be ignored by secret scanning?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/excluding-folders-and-files-from-secret-scanning"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files"
 ---
 
 - [x] By creating a `secret_scanning.yml` file within which you declare paths where fake secrets are located, so scans will omit them

--- a/questions/en/advanced_security/question-016.md
+++ b/questions/en/advanced_security/question-016.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the behavior when a new secret pattern is added or updated in the GitHub secret scanning partner program?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#accessing-secret-scanning-alerts"
+documentation: "https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning#accessing-secret-scanning-alerts"
 ---
 
 - [x] GitHub will run a scan of all historical code content in public repositories with secret scanning enabled

--- a/questions/en/advanced_security/question-023.md
+++ b/questions/en/advanced_security/question-023.md
@@ -1,6 +1,6 @@
 ---
 question: "What information do Dependabot alerts provide?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts"
 ---
 
 - [x] Dependabot alerts tell you that your repository uses a package that is insecure.

--- a/questions/en/advanced_security/question-024.md
+++ b/questions/en/advanced_security/question-024.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the GitHub dependency graph?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph"
 ---
 
 - [x] It is a representation of a repository's dependencies and dependents.

--- a/questions/en/advanced_security/question-025.md
+++ b/questions/en/advanced_security/question-025.md
@@ -1,6 +1,6 @@
 ---
 question: "Is GitHub dependency graph available for free to all repositories?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#dependency-graph-availability"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph#dependency-graph-availability"
 ---
 
 - [x] Yes, it's available for free for all repositories.

--- a/questions/en/advanced_security/question-026.md
+++ b/questions/en/advanced_security/question-026.md
@@ -1,6 +1,6 @@
 ---
 question: "How does GitHub Dependency graph know what dependencies your project is using?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph#supported-package-ecosystems"
 ---
 
 - [x] GitHub derives dependencies automatically from manifests and lock files committed to the repository

--- a/questions/en/advanced_security/question-028.md
+++ b/questions/en/advanced_security/question-028.md
@@ -1,6 +1,6 @@
 ---
 question: "In what format can you export the GitHub Dependency graph of your repository?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exporting-a-software-bill-of-materials-for-your-repository"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/export-dependencies-as-sbom"
 ---
 
 - [x] SPDX

--- a/questions/en/advanced_security/question-029.md
+++ b/questions/en/advanced_security/question-029.md
@@ -1,6 +1,6 @@
 ---
 question: "Can your repository use Dependency Graph without using Dependabot Alerts?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#using-the-dependency-graph"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph#using-the-dependency-graph"
 ---
 
 - [x] Yes

--- a/questions/en/advanced_security/question-030.md
+++ b/questions/en/advanced_security/question-030.md
@@ -1,6 +1,6 @@
 ---
 question: "Which feature is a pre-requisite for using Dependabot Alerts on a repository?"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#using-the-dependency-graph"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph#using-the-dependency-graph"
 ---
 
 - [x] Dependency graph

--- a/questions/en/advanced_security/question-031.md
+++ b/questions/en/advanced_security/question-031.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these statements about Dependabot Alerts are true?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts"
 ---
 
 - [x] They partially rely on the GitHub Advisory Database

--- a/questions/en/advanced_security/question-032.md
+++ b/questions/en/advanced_security/question-032.md
@@ -1,6 +1,6 @@
 ---
 question: "What are the primary benefits of the Security Overview feature in GitHub?"
-documentation: "https://docs.github.com/en/code-security/security-overview/about-security-overview"
+documentation: "https://docs.github.com/en/code-security/concepts/security-at-scale/security-overview"
 ---
 
 - [x] Centralized view of security alerts and policy management in an organization

--- a/questions/en/advanced_security/question-033.md
+++ b/questions/en/advanced_security/question-033.md
@@ -1,6 +1,6 @@
 ---
 question: "What is CodeQL?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql#about-code-scanning-with-codeql"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning-with-codeql#about-code-scanning-with-codeql"
 ---
 
 - [x] A code analysis engine developed by GitHub

--- a/questions/en/advanced_security/question-034.md
+++ b/questions/en/advanced_security/question-034.md
@@ -1,6 +1,6 @@
 ---
 question: "What do Dependabot alerts indicate in GitHub?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts#about-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts#about-dependabot-alerts"
 ---
 
 - [x] The presence of a vulnerable dependency or malware in your repository

--- a/questions/en/advanced_security/question-035.md
+++ b/questions/en/advanced_security/question-035.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the purpose of code scanning in GitHub?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning#about-code-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning#about-code-scanning"
 ---
 
 - [x] To identify vulnerabilities and errors in code

--- a/questions/en/advanced_security/question-036.md
+++ b/questions/en/advanced_security/question-036.md
@@ -1,6 +1,6 @@
 ---
 question: "Is secret scanning available for both public and private repositories on GitHub?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning#about-secret-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning#about-secret-scanning"
 ---
 
 - [x] Yes, but for private repositories, it requires a license for GitHub Advanced Security

--- a/questions/en/advanced_security/question-037.md
+++ b/questions/en/advanced_security/question-037.md
@@ -1,6 +1,6 @@
 ---
 question: "What does the default CodeQL analysis setup in GitHub do?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql#about-code-scanning-with-codeql"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning-with-codeql#about-code-scanning-with-codeql"
 ---
 
 - [x] Automatically detects languages, selects the default query suite, and configures scan triggers

--- a/questions/en/advanced_security/question-040.md
+++ b/questions/en/advanced_security/question-040.md
@@ -1,6 +1,6 @@
 ---
 question: "How does CodeQL analyze code in GitHub?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql#about-codeql"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning-with-codeql#about-codeql"
 ---
 
 - [x] It generates a CodeQL database and runs queries to identify problems, displaying results as code scanning alerts

--- a/questions/en/advanced_security/question-041.md
+++ b/questions/en/advanced_security/question-041.md
@@ -1,6 +1,6 @@
 ---
 question: "How can CodeQL be used in an external CI system together with GitHub repositories?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
 ---
 
 - [x] Run CodeQL CLI in the external CI system to scan code and upload the results to the GitHub repository

--- a/questions/en/advanced_security/question-042.md
+++ b/questions/en/advanced_security/question-042.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these statements isn't true about secret scanning on GitHub?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning"
 ---
 
 - [x] Secret scanning is a tool for secure secret storage and management.

--- a/questions/en/advanced_security/question-043.md
+++ b/questions/en/advanced_security/question-043.md
@@ -1,6 +1,6 @@
 ---
 question: "Which top-level keys are required in the `dependabot.yml` file?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file"
 ---
 
 - [x] `version` and `updates`

--- a/questions/en/advanced_security/question-045.md
+++ b/questions/en/advanced_security/question-045.md
@@ -1,6 +1,6 @@
 ---
 question: "Which tool can be used in a third-party CI system to upload code analysis results to GitHub?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
 ---
 
 - [x] CodeQL CLI

--- a/questions/en/advanced_security/question-046.md
+++ b/questions/en/advanced_security/question-046.md
@@ -1,6 +1,6 @@
 ---
 question: "What is required for a CI server to upload SARIF results to GitHub?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#generating-a-token-for-authentication-with-github"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#generating-a-token-for-authentication-with-github"
 ---
 
 - [x] A GitHub App or personal access token with `security_events` write permission.

--- a/questions/en/advanced_security/question-047.md
+++ b/questions/en/advanced_security/question-047.md
@@ -1,6 +1,6 @@
 ---
 question: "What happens when a second SARIF results file is uploaded to GitHub for a single commit?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#uploading-your-results-to-github"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#uploading-your-results-to-github"
 ---
 
 - [x] It replaces the original set of data.

--- a/questions/en/advanced_security/question-048.md
+++ b/questions/en/advanced_security/question-048.md
@@ -1,6 +1,6 @@
 ---
 question: "How can users exclude specific directories from secret scanning alerts on GitHub?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/configuring-secret-scanning-for-your-repositories#excluding-directories-from-secret-scanning-alerts-for-users"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files"
 ---
 
 - [x] By configuring a `secret_scanning.yml` file, under the `.github` path in the repository.

--- a/questions/en/advanced_security/question-049.md
+++ b/questions/en/advanced_security/question-049.md
@@ -1,6 +1,6 @@
 ---
 question: "Which key should be used in a `secret_scanning.yml` file to exclude directories from secret scanning alerts in GitHub?"
-documentation: "https://docs.github.com/en/code-security/secret-scanning/configuring-secret-scanning-for-your-repositories#excluding-directories-from-secret-scanning-alerts-for-users"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files"
 ---
 
 - [x] `paths-ignore:`

--- a/questions/en/advanced_security/question-051.md
+++ b/questions/en/advanced_security/question-051.md
@@ -1,6 +1,6 @@
 ---
 question: "Fill in the blank: `GitHub __________ is a feature that you can use to analyze code in a GitHub repository to find security vulnerabilities and coding errors.`"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning"
 ---
 
 - [x] Code Scanning

--- a/questions/en/advanced_security/question-052.md
+++ b/questions/en/advanced_security/question-052.md
@@ -1,6 +1,6 @@
 ---
 question: "Which GitHub Advanced Security feature allows you to find, triage, and prioritize fixes for new and existing problems in your code?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning"
 ---
 
 - [x] Code scanning

--- a/questions/en/advanced_security/question-053.md
+++ b/questions/en/advanced_security/question-053.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you enable code scanning for a repository?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configure-code-scanning"
 ---
 
 - [x] Go to the security tab of the repository settings and enable code scanning with default or advanced setup.

--- a/questions/en/advanced_security/question-054.md
+++ b/questions/en/advanced_security/question-054.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you configure your GitHub repository to run CodeQL analysis on a schedule?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning#about-default-setup"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configure-code-scanning#about-default-setup"
 ---
 
 - [x] By creating a GitHub Actions workflow with a `schedule` trigger. The workflow should leverage actions from the `github/codeql-action` repository.

--- a/questions/en/advanced_security/question-055.md
+++ b/questions/en/advanced_security/question-055.md
@@ -1,6 +1,6 @@
 ---
 question: "An organization has recently started using CodeQL analysis for all pull requests on their repositories as well as running the analysis on an hourly schedule. Since then they are experiencing larger than usual GitHub Actions bills. What is the most likely cause of this?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning#about-billing-for-code-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning#about-billing-for-code-scanning"
 ---
 
 - [x] Code scanning uses GitHub Actions and the organization is being billed for the additional usage.

--- a/questions/en/advanced_security/question-056.md
+++ b/questions/en/advanced_security/question-056.md
@@ -1,6 +1,6 @@
 ---
 question: "If you don't want to use GitHub Actions, you can run code scanning in an external CI system, then upload the results to GitHub."
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
 ---
 
 - [x] True

--- a/questions/en/advanced_security/question-057.md
+++ b/questions/en/advanced_security/question-057.md
@@ -1,6 +1,6 @@
 ---
 question: "When using a third party CI system to run code scanning, what GitHub tool do you need to analyze the codebase?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system#about-using-code-scanning-with-your-existing-ci-system"
 ---
 
 - [x] You don't specifically need a GitHub tool, any static analysis tool that can produce results in SARIF format will work.

--- a/questions/en/advanced_security/question-059.md
+++ b/questions/en/advanced_security/question-059.md
@@ -1,6 +1,6 @@
 ---
 question: "Can you use CodeQL analysis with third party CI systems?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/using-code-scanning-with-your-existing-ci-system"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/use-with-existing-ci-system"
 ---
 
 - [x] Yes, you just need to use the CodeQL CLI

--- a/questions/en/advanced_security/question-061.md
+++ b/questions/en/advanced_security/question-061.md
@@ -1,6 +1,6 @@
 ---
 question: "When using CodeQL analysis in your GitHub Actions workflow, how often is the scan triggered?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning#about-code-scanning"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning#about-code-scanning"
 ---
 
 - [x] Code scanning can be triggered for many different events that happen in the repository.

--- a/questions/en/advanced_security/question-062.md
+++ b/questions/en/advanced_security/question-062.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the effect of adding the `paths-ignore` keyword to your code scanning GitHub Actions workflow?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#avoiding-unnecessary-scans-of-pull-requests"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#avoiding-unnecessary-scans-of-pull-requests"
 ---
 
 ```yaml

--- a/questions/en/advanced_security/question-063.md
+++ b/questions/en/advanced_security/question-063.md
@@ -1,6 +1,6 @@
 ---
 question: "CodeQL scanning supports:"
-documentation: "https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql#about-codeql"
+documentation: "https://docs.github.com/en/code-security/concepts/code-scanning/code-scanning-with-codeql#about-codeql"
 ---
 
 - [x] Both compiled and interpreted languages

--- a/questions/en/advanced_security/question-074.md
+++ b/questions/en/advanced_security/question-074.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of the following statements about enabling CodeQL scanning default setup are true?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning"
+documentation: "https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configure-code-scanning"
 ---
 
 - [x] You can enable default setup for all eligible repositories in an organization at once in the organization settings

--- a/questions/en/advanced_security/question-075.md
+++ b/questions/en/advanced_security/question-075.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you customize your advanced CodeQL scanning setup with additional CodeQL query suites?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options"
 ---
 
 - [x] By using a custom configuration file and defining additional queries there

--- a/questions/en/advanced_security/question-077.md
+++ b/questions/en/advanced_security/question-077.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the simplest method to execute CodeQL analysis concurrently for each language in a multi-language repository using GitHub Actions?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#changing-the-languages-that-are-analyzed"
 ---
 
 - [x] By creating a `languages` matrix for the job and then reference it in the `github/codeql-action/init` action's `languages` input parameter

--- a/questions/en/advanced_security/question-078.md
+++ b/questions/en/advanced_security/question-078.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you use a custom CodeQL configuration file in a GitHub Actions workflow?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-a-custom-configuration-file"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#using-a-custom-configuration-file"
 ---
 
 - [x] By explicitly providing the configuration file path in the `config-file` input parameter of the `github/codeql-action/init` action

--- a/questions/en/advanced_security/question-079.md
+++ b/questions/en/advanced_security/question-079.md
@@ -1,6 +1,6 @@
 ---
 question: "Where can you specify the CodeQL queries to run in a GitHub Actions workflow?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#running-additional-queries"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#running-additional-queries"
 ---
 
 - [x] In the `queries` input parameter of the `github/codeql-action/init` action

--- a/questions/en/advanced_security/question-080.md
+++ b/questions/en/advanced_security/question-080.md
@@ -1,6 +1,6 @@
 ---
 question: "What is the purpose of the `external-repository-token` parameter in `github/codeql-action/init` GitHub Action?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-queries-in-ql-packs"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#using-queries-in-ql-packs"
 ---
 
 - [x] It allows the action to access a private GitHub repository that contains configuration files, queries or packs that are required for the analysis.

--- a/questions/en/advanced_security/question-085.md
+++ b/questions/en/advanced_security/question-085.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these statements regarding viewing the results of a CodeQL analysis are true?"
-documentation: "https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/assessing-code-scanning-alerts-for-your-repository"
+documentation: "https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-code-scanning-alerts/assess-alerts"
 ---
 
 - [x] You need write permission to view a summary of all the alerts for a repository in the Security tab.

--- a/questions/en/advanced_security/question-089.md
+++ b/questions/en/advanced_security/question-089.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these is NOT a valid approach one can take to reduce the time it takes for CodeQL analysis workflow to complete?" 
-documentation: "https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/analysis-takes-too-long"
+documentation: "https://docs.github.com/en/code-security/reference/code-scanning/troubleshoot-analysis-errors/analysis-takes-too-long"
 ---
 
 - [x] Run the analysis on every push event

--- a/questions/en/advanced_security/question-099.md
+++ b/questions/en/advanced_security/question-099.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these statements best defines a vulnerable dependency?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts"
 ---
 
 - [x] A vulnerable dependency is dependency that a project relies on, which contains security flaws that could potentially be exploited, compromising the project's security.

--- a/questions/en/advanced_security/question-100.md
+++ b/questions/en/advanced_security/question-100.md
@@ -1,6 +1,6 @@
 ---
 question: "What are Dependabot security updates?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-security-updates/about-dependabot-security-updates"
 ---
 
 - [x] It's a Dependabot feature that automatically creates pull requests to update vulnerable dependencies in your repository.

--- a/questions/en/advanced_security/question-101.md
+++ b/questions/en/advanced_security/question-101.md
@@ -1,6 +1,6 @@
 ---
 question: "Dependabot Alerts are enabled by default on:"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts#configuration-of-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts#configuration-of-dependabot-alerts"
 ---
 
 - [x] Dependabot Alerts are not enabled by default on any repositories.

--- a/questions/en/advanced_security/question-102.md
+++ b/questions/en/advanced_security/question-102.md
@@ -1,6 +1,6 @@
 ---
 question: "Who can enable Dependabot alerts on a repository?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts#configuration-of-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/about-dependabot-alerts#configuration-of-dependabot-alerts"
 ---
 
 - [x] Repository owners and people with admin access

--- a/questions/en/advanced_security/question-104.md
+++ b/questions/en/advanced_security/question-104.md
@@ -1,6 +1,6 @@
 ---
 question: "To enable Dependabot Alerts on all repositories in an organization you should:"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts#enabling-or-disabling-dependabot-alerts-for-all-existing-repositories"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/configuring-dependabot-alerts#enabling-or-disabling-dependabot-alerts-for-all-existing-repositories"
 ---
 
 - [x] Go to the organization's `Code security and analysis` settings and enable Dependabot Alerts for all repositories at once.

--- a/questions/en/advanced_security/question-105.md
+++ b/questions/en/advanced_security/question-105.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these is a valid `dependabot.yml` configuration file?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file"
 ---
 
 - [x] 

--- a/questions/en/advanced_security/question-106.md
+++ b/questions/en/advanced_security/question-106.md
@@ -1,6 +1,6 @@
 ---
 question: "Which of these is not a GitHub supported channel for receiving Dependabot alerts?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-notifications-for-dependabot-alerts#configuring-notifications-for-dependabot-alerts"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-alerts/configuring-notifications-for-dependabot-alerts#configuring-notifications-for-dependabot-alerts"
 ---
 
 - [x] SMS/Call

--- a/questions/en/advanced_security/question-107.md
+++ b/questions/en/advanced_security/question-107.md
@@ -1,6 +1,6 @@
 ---
 question: "What are Dependabot auto-triage rules?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules"
 ---
 
 - [x] It's a feature that allows Dependabot to automatically dismiss Dependabot alerts that match certain criteria.

--- a/questions/en/advanced_security/question-108.md
+++ b/questions/en/advanced_security/question-108.md
@@ -1,6 +1,6 @@
 ---
 question: "How can you automate dismissing low severity Dependabot alerts?"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-auto-triage-rules/about-dependabot-auto-triage-rules"
 ---
 
 - [x] By using Dependabot's auto-triage rules.

--- a/questions/en/advanced_security/question-110.md
+++ b/questions/en/advanced_security/question-110.md
@@ -1,6 +1,6 @@
 ---
 question: "The tool that checks if a pull request introduces any dependencies with security vulnerabilities is called:"
-documentation: "https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review"
+documentation: "https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-review"
 ---
 
 - [x] Dependency Review

--- a/questions/en/advanced_security/question-111.md
+++ b/questions/en/advanced_security/question-111.md
@@ -1,6 +1,6 @@
 ---
 question: "You need GitHub Actions enabled for"
-documentation: "https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#about-dependabot-version-updates"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/dependabot-version-updates/about-dependabot-version-updates#about-dependabot-version-updates"
 ---
 
 - [x] Dependency Review

--- a/questions/en/advanced_security/question-113.md
+++ b/questions/en/advanced_security/question-113.md
@@ -1,6 +1,6 @@
 ---
 question: "What does `CVE` stand for?"
-documentation: "https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories#cve-identification-numbers"
+documentation: "https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories#cve-identification-numbers"
 ---
 
 - [x] `Common Vulnerabilities and Exposures`

--- a/questions/en/advanced_security/question-115.md
+++ b/questions/en/advanced_security/question-115.md
@@ -1,6 +1,6 @@
 ---
 question: "Which Dependabot comment command will get a pull request successfully completed?"
-documentation: "https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands"
+documentation: "https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands"
 ---
 
 - [ ] `@dependabot close`


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [x] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?
Replaces the per-exam GitHub issue reports in `.github/workflows/link-checker.yml` with an auto-fix flow powered by Copilot CLI's new `GITHUB_TOKEN`-based auth (no PAT required):

- Lychee now scans all of `questions/en/**/*.md` in a single run instead of a per-exam matrix (no more one issue per exam)
- Report/summary file paths (`lychee/out.md`, `summary.md`) are parametrized via workflow `env`
- On broken/redirected links, Copilot CLI is installed and run non-interactively (`--no-ask-user`) to:
  - fix redirected links to their final resolved URL
  - fix broken (4xx/5xx) links only when a replacement is obviously correct, otherwise leave them and list as unresolved
  - only touch files under `questions/en/`
- A PR is then opened via `peter-evans/create-pull-request`, scoped to `questions/en/**`, with Copilot's fixed/unresolved summary as the PR body
- Skips the whole fix flow on `pull_request` triggers (used only to validate workflow syntax changes)

## Related issue(s)
N/A

## Screenshots
N/A
