### PR TITLE
fix: correct grammar and typos in action questions

### DIFF
--- a/questions/en/actions/question-071.md
+++ b/questions/en/actions/question-071.md
@@ -4,10 +4,10 @@ documentation: "https://docs.github.com/en/actions/reference/security/secrets"
 ---
 
 - [x] By creating a repository secret with the same name `API_KEY`
-- [x] By creating a environment secret with the same name `API_KEY`
-- [ ] By creating a enterprise secret with the same name `API_KEY`
-- [ ] By creating a enterprise secret with the name `OVERRIDE_API_KEY`
+- [x] By creating an environment secret with the same name `API_KEY`
+- [ ] By creating an enterprise secret with the same name `API_KEY`
+- [ ] By creating an enterprise secret with the name `OVERRIDE_API_KEY`
 - [ ] By creating a repository secret with the name `OVERRIDE_API_KEY`
-- [ ] By creating a environment secret with the name `OVERRIDE_API_KEY`
+- [ ] By creating an environment secret with the name `OVERRIDE_API_KEY`
 - [ ] By creating a repository secret with the name `REPOSITORY_API_KEY`
-- [ ] By creating a environment secret with the name `ENVIRONMENT_API_KEY`
+- [ ] By creating an environment secret with the name `ENVIRONMENT_API_KEY`

--- a/questions/en/actions/question-158.md
+++ b/questions/en/actions/question-158.md
@@ -33,7 +33,7 @@ jobs:
     post-merge:
 ``` 
 > The `pull_request` event does not have a `merged` activity type.
-- [ ] Specify the the `pull_request` activity type as `closed` (no need for a job-level conditional)
+- [ ] Specify the `pull_request` activity type as `closed` (no need for a job-level conditional)
 ```yaml
 on:
     pull_request:
@@ -42,7 +42,7 @@ jobs:
     post-merge:
 ``` 
 > Pull requests can be closed without being merged. If you do not use a corresponding job-level conditional that checks whether the PR was merged, then the job will fire any time a PR is closed, not just when merging occurred.
-- [ ]  Specify the the `pull_request` activity type as `closed` and use a job-level conditional to check if `github.ref` is equal to the merge branch of the pull request.
+- [ ]  Specify the `pull_request` activity type as `closed` and use a job-level conditional to check if `github.ref` is equal to the merge branch of the pull request.
 ```yaml
 on:
     pull_request:


### PR DESCRIPTION
## PR Type

- [ ] Adding new question(s)
- [x] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other

## What's new?

This pull request makes minor **grammar** and **typo** corrections in two **GitHub Actions questions**:

* Fixed grammar in the answer choices by changing "a" to "an" before "environment" and "enterprise" in `questions/en/actions/question-071.md`.
* Removed the duplicate "the" from the answer choices in `questions/en/actions/question-158.md`. 