### PR TITLE
feat(admin): add question 097 on checkout fetch-depth

### DIFF
--- a/questions/en/admin/question-097.md
+++ b/questions/en/admin/question-097.md
@@ -1,0 +1,13 @@
+---
+question: "Your GitHub Actions workflow runs on every push to main. You want to keep checkout fast by downloading only the minimum Git history required, but a later step needs to run `git diff HEAD^ HEAD`. Which `actions/checkout` configuration should you use?"
+documentation: "https://github.com/actions/checkout"
+---
+
+- [ ] `fetch-depth: 0`
+> `fetch-depth: 0` fetches the entire Git history, which satisfies the diff requirement but is slower than fetching only the required commits.
+- [ ] `fetch-depth: 1`
+> `fetch-depth: 1` fetches only the single commit being checked out (the default behavior), so `HEAD^` does not exist.
+- [x] `fetch-depth: 2`
+> `fetch-depth: 2` fetches the current commit and its immediate parent (`HEAD^`), which is the minimum depth required.
+- [ ] `fetch-depth: 5`
+> `fetch-depth: 5` fetches 5 commits, which works but downloads more history than the minimum required.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Adding new question(s)
> **Warning**: We do not support the inclusion of questions directly copied from official GitHub certification exams. Please only submit original questions and content that you have created.
- [ ] Other content changes (updating questions, answers, explanations or study resources)
- [ ] Code changes (non-content)
- [ ] Documentation changes
- [ ] Other


## What's new?

Adds a new original practice question `question-097.md` under `questions/en/admin/` for the GitHub Administrator exam.
- **Topic**: `actions/checkout` depth configuration (`fetch-depth`).
- **Scenario**: Selecting the minimum Git history depth (`fetch-depth: 2`) required for `git diff HEAD^ HEAD` to keep checkout fast while ensuring parent commit availability.


## Related issue(s)
N/A

## Screenshots
N/A
